### PR TITLE
Fixed wrong function output and extended the mash function

### DIFF
--- a/pybeerxml/fermentable.py
+++ b/pybeerxml/fermentable.py
@@ -19,7 +19,7 @@ class Fermentable(object):
 
     @add_after_boil.setter
     def add_after_boil(self, value):
-        print(value)
+        return value
         self._add_after_boil = value
 
     @property

--- a/pybeerxml/parser.py
+++ b/pybeerxml/parser.py
@@ -78,19 +78,16 @@ class Parser(object):
                     self.nodes_to_object(recipeProperty, style)
 
                 elif tag_name == "mash":
+                    mash = Mash()
+                    recipe.mash = mash
+                    self.nodes_to_object(recipeProperty, mash)
 
                     for mash_node in list(recipeProperty):
-                        mash = Mash()
-                        recipe.mash = mash
-
                         if self.to_lower(mash_node.tag) == "mash_steps":
                             for mash_step_node in list(mash_node):
                                 mash_step = MashStep()
                                 self.nodes_to_object(mash_step_node, mash_step)
                                 mash.steps.append(mash_step)
-                        else:
-                            self.nodes_to_object(mash_node, mash)
-
                 else:
                     self.node_to_object(recipeProperty, recipe)
 


### PR DESCRIPTION
- Changed the print to return because it will not work otherwise
- The mash function of parser.py works only with elements in the <mash_steps> tag and not with elements in <mash> as the recipe examples at http://www.beerxml.com/recipes.xml shows