### PR TITLE
corrected issue with mash step parsing

### DIFF
--- a/pybeerxml/parser.py
+++ b/pybeerxml/parser.py
@@ -85,11 +85,10 @@ class Parser(object):
                     self.nodes_to_object(recipeProperty, style)
 
                 elif tag_name == "mash":
+                    mash = Mash()
+                    recipe.mash = mash
 
                     for mash_node in list(recipeProperty):
-                        mash = Mash()
-                        recipe.mash = mash
-
                         if self.to_lower(mash_node.tag) == "mash_steps":
                             for mash_step_node in list(mash_node):
                                 mash_step = MashStep()


### PR DESCRIPTION
(wonderful utility!) I'm using this in a project and noticed that BrewTarget exports BeerXML such that subsequent mash "steps" overwrite the actual mash steps.  My proposed correction creates a single "mash" object and them populates it, similar to the other objects (fermentables, hops, etc.).

This is an example [CoffeeStout.zip](https://github.com/hotzenklotz/pybeerxml/files/3581944/CoffeeStout.zip) recipe that previously would cause index errors during my parsing as the mash was being obliterated.  With my change it seems to work as expected, at least in my application.

I do apologize, if I had more time I would create a mash test case for you to catch this in the future, however, life persists.  If you choose to accept my change, hooray!

