### PR TITLE
Fix "'>' not supported between instances of 'NoneType' and 'int'"

### DIFF
--- a/pybeerxml/recipe.py
+++ b/pybeerxml/recipe.py
@@ -226,7 +226,7 @@ class Recipe:
 
         # Get attenuation for final gravity
         for yeast in self.yeasts:
-            if yeast.attenuation > attenuation:
+            if yeast.attenuation is not None and yeast.attenuation > attenuation:
                 attenuation = yeast.attenuation
 
         if attenuation == 0:


### PR DESCRIPTION
Fix a small issue when you try to calculate `fg`, but `attenuation` is not set on the yeast.