### PR TITLE
Extra fields for yeast

### DIFF
--- a/pybeerxml/recipe.py
+++ b/pybeerxml/recipe.py
@@ -58,11 +58,11 @@ class Recipe:
         self.carbonation_used: Optional[Text] = None
 
         # Values from the recipe, which are calculated as a fallback
-        self._abv = None
-        self._og = None
-        self._fg = None
-        self._ibu = None
-        self._color = None
+        self._abv: Optional[float] = None
+        self._og: Optional[float] = None
+        self._fg: Optional[float] = None
+        self._ibu: Optional[float] = None
+        self._color: Optional[float] = None
 
         self.style: Optional[Style] = None
         self.hops: List[Hop] = []

--- a/pybeerxml/yeast.py
+++ b/pybeerxml/yeast.py
@@ -1,9 +1,12 @@
-from typing import Optional, Text
+from typing import Optional, Text, Any
+
+from pybeerxml.utils import cast_to_bool
 
 
 class Yeast:
     def __init__(self):
         self.name: Optional[Text] = None
+        self.version: Optional[int] = None
         self.type: Optional[Text] = None
         self.form: Optional[Text] = None  # May be "Liquid", "Dry", "Slant" or "Culture"
         self.attenuation: Optional[float] = None  # Percent
@@ -13,3 +16,35 @@ class Yeast:
         self.flocculation: Optional[
             Text
         ] = None  # May be "Low", "Medium", "High" or "Very High"
+        self.amount: Optional[float] = None
+        self._amount_is_weight: Optional[bool] = None
+        self.min_temperature: Optional[float] = None
+        self.max_temperature: Optional[float] = None
+        self.best_for: Optional[Text] = None
+        self.times_cultured: Optional[int] = None
+        self.max_reuse: Optional[int] = None
+        self._add_to_secondary: Optional[bool] = None
+        self.inventory: Optional[Text] = None
+        self.culture_date: Optional[Text] = None
+
+    @property
+    def amount_is_weight(self) -> Optional[bool]:
+        if self._amount_is_weight is not None:
+            return self._amount_is_weight
+
+        return None
+
+    @amount_is_weight.setter
+    def amount_is_weight(self, value: Any):
+        self._amount_is_weight = cast_to_bool(value)
+
+    @property
+    def add_to_secondary(self) -> Optional[bool]:
+        if self._add_to_secondary is not None:
+            return self._add_to_secondary
+
+        return None
+
+    @add_to_secondary.setter
+    def add_to_secondary(self, value: Any):
+        self._add_to_secondary = cast_to_bool(value)

--- a/tests/CoffeeStout.xml
+++ b/tests/CoffeeStout.xml
@@ -195,7 +195,7 @@
     <NOTES>This extremely flocculent yeast produces distincly malty beers. Attenuation levels are typically less than most other yeast strains making a slightly sweeter finish. Ales produced with this strain tend to be fruity, increasingly so with higher fermentation temperatures (21-23C). Diacetyl production is noticeable and a thorough rest is necessary. A very good cask conditioned ale strain due to thorough flocculation. Bright beers easily achieved with days without filtration.
  </NOTES>
     <BEST_FOR>Ordinary/Special Bitters, ESB, Mild Ale, Southern English Brown, English IPA, Strong/Old Ale, English Barley Wine, Wood Aged Ale, Spiced/Herb/Vegetable Ale, Fruit Ale</BEST_FOR>
-    <TIMES_CULTURED>0</TIMES_CULTURED>
+    <TIMES_CULTURED>1</TIMES_CULTURED>
     <MAX_REUSE>0</MAX_REUSE>
     <ADD_TO_SECONDARY>FALSE</ADD_TO_SECONDARY>
    </YEAST>

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -301,6 +301,24 @@ def assert_coffee_stout_recipe(recipes):
     assert recipe.equipment.hop_utilization == 100.0
     assert recipe.equipment.notes == "Equipment notes"
 
+    assert recipe.yeasts[0].name == "Wyeast - London ESB Ale"
+    assert recipe.yeasts[0].version == 1
+    assert recipe.yeasts[0].type == "Ale"
+    assert recipe.yeasts[0].form == "Liquid"
+    assert recipe.yeasts[0].amount == 0.125
+    assert not recipe.yeasts[0].amount_is_weight
+    assert recipe.yeasts[0].laboratory == "Wyeast Labs"
+    assert recipe.yeasts[0].product_id == 1968
+    assert recipe.yeasts[0].min_temperature == 18
+    assert recipe.yeasts[0].max_temperature == 22
+    assert recipe.yeasts[0].flocculation == "Very High"
+    assert recipe.yeasts[0].attenuation == 69.0
+    assert recipe.yeasts[0].notes.startswith("This extremely flocculent yeast produces")
+    assert recipe.yeasts[0].best_for.startswith("Ordinary/Special Bitters, ESB")
+    assert recipe.yeasts[0].times_cultured == 1
+    assert recipe.yeasts[0].max_reuse == 0
+    assert not recipe.yeasts[0].add_to_secondary
+
 
 def test_node_to_object():
     "test XML node parsing to Python object"


### PR DESCRIPTION
This is adding some new fields to the `Yeast` class. Sorry, I should have added these earlier in my first "extra fields" PR.

Also added some missing type hints on the `Recipe` class.

pylint is complaining about duplicate code, not sure how to deal with this. Adding `# pylint: disable=duplicate-code` to misc,py and yeast.py didn't work for me.