### PR TITLE
Fixed import path in example.

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,7 +20,7 @@ pip install pybeerxml
 ## Usage
 
 ```
-from pybeerxml import Parser
+from pybeerxml.parser import Parser
 
 path_to_beerxml_file = "/tmp/SimcoeIPA.beerxml"
 


### PR DESCRIPTION
Noticed when I upgraded from 1.0.6 to 2.x.x the import path changed for the parser class.  This updates the example in the README to work as expected.