### PR TITLE
Refactor BeerXML parsing and serialization around pydantic-xml

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # pybeerxml
 
-A simple BeerXML parser for Python
+A simple BeerXML parser and serializer for Python
 
 [![PyPi Version](https://img.shields.io/pypi/v/pybeerxml.svg?style=flat-square)](https://pypi.python.org/pypi?:action=display&name=pybeerxml)
 [![Build Status](https://img.shields.io/github/actions/workflow/status/hotzenklotz/pybeerxml/test_lint.yaml?branch=master&style=flat-square)](https://github.com/hotzenklotz/pybeerxml/actions/workflows/test_lint.yaml)
@@ -9,8 +9,8 @@ A simple BeerXML parser for Python
 
 
 Parses all recipes within a BeerXML file and returns `Recipe` objects containing all ingredients,
-style information and metadata. OG, FG, ABV and IBU are calculated from the ingredient list. (your
-milage may vary)
+style information and metadata. It can also serialize `Recipe` objects back into BeerXML documents.
+OG, FG, ABV and IBU are calculated from the ingredient list. (your milage may vary)
 
 ## Installation
 
@@ -22,12 +22,13 @@ pip install pybeerxml
 
 Full documentation is available at [pybeerxml.onrender.com](https://pybeerxml.onrender.com/).
 
-```
-from pybeerxml import Parser
+```python
+from pybeerxml import Parser, Serializer
 
 path_to_beerxml_file = "/tmp/SimcoeIPA.beerxml"
 
 parser = Parser()
+serializer = Serializer()
 recipes = parser.parse(path_to_beerxml_file)
 
 for recipe in recipes:
@@ -54,6 +55,9 @@ for recipe in recipes:
 
     for misc in recipe.miscs:
         print(misc.name)
+
+xml = serializer.serialize(recipes)
+serializer.write(recipes, "/tmp/SimcoeIPA-out.beerxml")
 ```
 
 ## Testing

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -5,13 +5,17 @@ description: Full API reference for pybeerxml
 
 # API Reference
 
-pybeerxml exposes one entry point — the `Parser` class — which returns `Recipe` objects. Each `Recipe` holds typed ingredient and metadata objects.
+pybeerxml exposes two main entry points:
+
+- `Parser` reads BeerXML into `Recipe` objects
+- `Serializer` writes `Recipe` objects back to BeerXML
 
 ## Class overview
 
 | Class | Description |
 |-------|-------------|
 | [`Parser`](parser.md) | Reads BeerXML files or strings and returns `Recipe` objects |
+| [`Serializer`](serializer.md) | Writes one or more `Recipe` objects to BeerXML |
 | [`Recipe`](recipe.md) | A complete beer recipe with calculated properties |
 | [`Fermentable`](fermentable.md) | A grain, extract, sugar, or adjunct |
 | [`Hop`](hop.md) | A hop addition with bitterness calculation |
@@ -25,7 +29,7 @@ pybeerxml exposes one entry point — the `Parser` class — which returns `Reci
 ## Import paths
 
 ```python
-from pybeerxml import Parser          # main entry point
+from pybeerxml import Parser, Serializer
 from pybeerxml.recipe import Recipe
 from pybeerxml.fermentable import Fermentable
 from pybeerxml.hop import Hop

--- a/docs/api/serializer.md
+++ b/docs/api/serializer.md
@@ -1,0 +1,3 @@
+# Serializer
+
+::: pybeerxml.serializer.Serializer

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -1,6 +1,6 @@
 ---
 title: Getting Started
-description: Install pybeerxml and parse your first BeerXML recipe file
+description: Install pybeerxml and parse or serialize your first BeerXML recipe file
 ---
 
 # Getting Started
@@ -45,6 +45,31 @@ xml = open("recipe.beerxml").read()
 
 parser = Parser()
 recipes = parser.parse_from_string(xml)
+```
+
+## Serializing recipes
+
+Use `Serializer` to write one or more `Recipe` objects back to BeerXML:
+
+```python
+from pybeerxml import Parser, Serializer
+
+parser = Parser()
+serializer = Serializer()
+
+recipes = parser.parse("/path/to/recipe.beerxml")
+
+xml = serializer.serialize(recipes)
+serializer.write(recipes, "/path/to/output.beerxml")
+```
+
+For single-recipe convenience, `Recipe` also exposes write helpers:
+
+```python
+recipe = recipes[0]
+
+xml = recipe.to_xml_string()
+recipe.write_xml("/path/to/single-recipe.beerxml")
 ```
 
 ## Calculated vs. stored values

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,6 +1,6 @@
 ---
 title: pybeerxml
-description: A BeerXML parser for Python
+description: A BeerXML parser and serializer for Python
 ---
 
 # pybeerxml
@@ -9,11 +9,12 @@ description: A BeerXML parser for Python
 [![Build Status](https://img.shields.io/github/actions/workflow/status/hotzenklotz/pybeerxml/test_lint.yaml?branch=master&style=flat-square)](https://github.com/hotzenklotz/pybeerxml/actions/workflows/test_lint.yaml)
 [![Docs](https://img.shields.io/badge/docs-pybeerxml.onrender.com-blue?style=flat-square)](https://pybeerxml.onrender.com/)
 
-**pybeerxml** is a Python library for parsing [BeerXML](http://www.beerxml.com/) recipe files. It reads all recipes from a `.beerxml` file and returns structured `Recipe` objects — including ingredients, style metadata, and automatically calculated values for OG, FG, ABV, IBU, and colour.
+**pybeerxml** is a Python library for parsing and serializing [BeerXML](http://www.beerxml.com/) recipe files. It reads `.beerxml` documents into structured `Recipe` objects and can write those objects back into valid BeerXML.
 
 ## Features
 
 - Parse BeerXML files or XML strings
+- Serialize one or more recipes back to BeerXML
 - Access hops, fermentables, yeasts, miscs, mash steps, equipment, and style
 - Automatic calculation of OG, FG, ABV, IBU, and colour when not provided in the XML
 - Supports both Tinseth and Rager IBU formulas
@@ -22,9 +23,10 @@ description: A BeerXML parser for Python
 ## Quick Example
 
 ```python
-from pybeerxml import Parser
+from pybeerxml import Parser, Serializer
 
 parser = Parser()
+serializer = Serializer()
 recipes = parser.parse("/path/to/recipe.beerxml")
 
 for recipe in recipes:
@@ -38,6 +40,9 @@ for recipe in recipes:
 
     for fermentable in recipe.fermentables:
         print(fermentable.name, fermentable.amount)
+
+xml = serializer.serialize(recipes)
+serializer.write(recipes, "/path/to/output.beerxml")
 ```
 
 ## Installation

--- a/pybeerxml/__init__.py
+++ b/pybeerxml/__init__.py
@@ -1,5 +1,5 @@
 from pybeerxml.parser import Parser
 from pybeerxml.recipe import Recipe
-from pybeerxml.serializer import serialize, write
+from pybeerxml.serializer import Serializer
 
-__all__ = ["Parser", "Recipe", "serialize", "write"]
+__all__ = ["Parser", "Serializer", "Recipe"]

--- a/pybeerxml/__init__.py
+++ b/pybeerxml/__init__.py
@@ -1,3 +1,5 @@
 from pybeerxml.parser import Parser
+from pybeerxml.recipe import Recipe
+from pybeerxml.serializer import serialize, write
 
-__all__ = ["Parser"]
+__all__ = ["Parser", "Recipe", "serialize", "write"]

--- a/pybeerxml/document.py
+++ b/pybeerxml/document.py
@@ -1,0 +1,12 @@
+from __future__ import annotations
+
+from pydantic_xml import element
+
+from pybeerxml.recipe import Recipe
+from pybeerxml.xml_model import BeerXmlModel
+
+
+class RecipesDocument(BeerXmlModel, tag="RECIPES"):
+    """BeerXML document root containing one or more recipes."""
+
+    recipes: list[Recipe] = element(tag="RECIPE", default_factory=list)

--- a/pybeerxml/equipment.py
+++ b/pybeerxml/equipment.py
@@ -1,15 +1,14 @@
-from dataclasses import dataclass, field
-from typing import Any
+from pydantic_xml import element
 
-from pybeerxml.utils import cast_to_bool
+from pybeerxml.xml_model import BeerBool, BeerFloat, BeerInt, BeerXmlModel
 
 
-@dataclass
-class Equipment:
+class Equipment(BeerXmlModel, tag="EQUIPMENT"):
     """Brewing equipment profile from a BeerXML ``<EQUIPMENT>`` element.
 
     Attributes:
         name: Equipment set name.
+        version: BeerXML equipment profile version.
         boil_size: Pre-boil kettle volume in litres.
         batch_size: Target post-boil batch volume in litres.
         tun_volume: Mash tun capacity in litres.
@@ -25,28 +24,19 @@ class Equipment:
         notes: Free-text notes.
     """
 
-    name: str | None = None
-    version: int | None = None
-    boil_size: float | None = None
-    batch_size: float | None = None
-    tun_volume: float | None = None
-    tun_weight: float | None = None
-    tun_specific_heat: float | None = None
-    top_up_water: float | None = None
-    trub_chiller_loss: float | None = None
-    evap_rate: float | None = None
-    boil_time: float | None = None
-    lauter_deadspace: float | None = None
-    top_up_kettle: float | None = None
-    hop_utilization: float | None = None
-    notes: str | None = None
-    _calc_boil_volume: bool | None = field(default=None, init=False, repr=False)
-
-    @property
-    def calc_boil_volume(self) -> bool | None:
-        """Whether the pre-boil volume should be calculated from equipment parameters."""
-        return self._calc_boil_volume
-
-    @calc_boil_volume.setter
-    def calc_boil_volume(self, value: Any) -> None:
-        self._calc_boil_volume = cast_to_bool(value)
+    name: str | None = element(tag="NAME", default=None)
+    version: BeerInt | None = element(tag="VERSION", default=None)
+    boil_size: BeerFloat | None = element(tag="BOIL_SIZE", default=None)
+    batch_size: BeerFloat | None = element(tag="BATCH_SIZE", default=None)
+    tun_volume: BeerFloat | None = element(tag="TUN_VOLUME", default=None)
+    tun_weight: BeerFloat | None = element(tag="TUN_WEIGHT", default=None)
+    tun_specific_heat: BeerFloat | None = element(tag="TUN_SPECIFIC_HEAT", default=None)
+    top_up_water: BeerFloat | None = element(tag="TOP_UP_WATER", default=None)
+    trub_chiller_loss: BeerFloat | None = element(tag="TRUB_CHILLER_LOSS", default=None)
+    evap_rate: BeerFloat | None = element(tag="EVAP_RATE", default=None)
+    boil_time: BeerFloat | None = element(tag="BOIL_TIME", default=None)
+    calc_boil_volume: BeerBool | None = element(tag="CALC_BOIL_VOLUME", default=None)
+    lauter_deadspace: BeerFloat | None = element(tag="LAUTER_DEADSPACE", default=None)
+    top_up_kettle: BeerFloat | None = element(tag="TOP_UP_KETTLE", default=None)
+    hop_utilization: BeerFloat | None = element(tag="HOP_UTILIZATION", default=None)
+    notes: str | None = element(tag="NOTES", default=None)

--- a/pybeerxml/equipment.py
+++ b/pybeerxml/equipment.py
@@ -26,7 +26,7 @@ class Equipment:
     """
 
     name: str | None = None
-    version: str | None = None
+    version: int | None = None
     boil_size: float | None = None
     batch_size: float | None = None
     tun_volume: float | None = None

--- a/pybeerxml/fermentable.py
+++ b/pybeerxml/fermentable.py
@@ -3,7 +3,7 @@ import re
 
 from pydantic_xml import element
 
-from pybeerxml.xml_model import BeerBool, BeerFloat, BeerInt, BeerXmlModel
+from pybeerxml.xml_model import BeerBool, BeerFloat, BeerInt, BeerXmlModel, coerce_float
 
 logger = logging.getLogger(__name__)
 
@@ -61,23 +61,7 @@ class Fermentable(BeerXmlModel, tag="FERMENTABLE"):
 
     @_yield.setter
     def _yield(self, value: float | int | str | None) -> None:
-        self.yield_pct = value
-
-    @property
-    def _add_after_boil(self) -> bool | None:
-        return self.add_after_boil
-
-    @_add_after_boil.setter
-    def _add_after_boil(self, value: bool | str | int | float | None) -> None:
-        self.add_after_boil = value
-
-    @property
-    def _recommend_mash(self) -> bool | None:
-        return self.recommend_mash
-
-    @_recommend_mash.setter
-    def _recommend_mash(self, value: bool | str | int | float | None) -> None:
-        self.recommend_mash = value
+        self.yield_pct = coerce_float(value)
 
     @property
     def ppg(self) -> float | None:

--- a/pybeerxml/fermentable.py
+++ b/pybeerxml/fermentable.py
@@ -1,9 +1,9 @@
 import logging
 import re
-from dataclasses import dataclass, field
-from typing import Any
 
-from pybeerxml.utils import cast_to_bool
+from pydantic_xml import element
+
+from pybeerxml.xml_model import BeerBool, BeerFloat, BeerInt, BeerXmlModel
 
 logger = logging.getLogger(__name__)
 
@@ -17,14 +17,14 @@ STEEP = re.compile(r"biscuit|black|cara|chocolate|crystal|munich|roast|special|t
 BOIL = re.compile(r"candi|candy|dme|dry|extract|honey|lme|liquid|sugar|syrup|turbinado", re.IGNORECASE)
 
 
-@dataclass
-class Fermentable:
+class Fermentable(BeerXmlModel, tag="FERMENTABLE"):
     """A fermentable ingredient — grain, extract, sugar, or adjunct.
 
     Attributes:
         name: Ingredient name.
         amount: Weight in kilograms.
         color: Colour contribution in degrees Lovibond (°L).
+        version: BeerXML fermentable record version.
         type: Ingredient type (e.g. ``"Grain"``, ``"Extract"``, ``"Sugar"``).
         origin: Country of origin.
         supplier: Supplier or maltster name.
@@ -37,33 +37,47 @@ class Fermentable:
         ibu_gal_per_lb: IBU contribution per gallon per pound (for adjuncts).
     """
 
-    name: str | None = None
-    amount: float | None = None
-    color: float | None = None
-    version: int | None = None
-    type: str | None = None
-    origin: str | None = None
-    supplier: str | None = None
-    notes: str | None = None
-    coarse_fine_diff: float | None = None
-    moisture: float | None = None
-    diastatic_power: float | None = None
-    protein: float | None = None
-    max_in_batch: float | None = None
-    ibu_gal_per_lb: float | None = None
-    # "yield" is a Python keyword, so the parser maps it to _yield via setattr
-    _yield: float | None = field(default=None, init=False, repr=False)
-    _add_after_boil: bool | None = field(default=None, init=False, repr=False)
-    _recommend_mash: bool | None = field(default=None, init=False, repr=False)
+    name: str | None = element(tag="NAME", default=None)
+    amount: BeerFloat | None = element(tag="AMOUNT", default=None)
+    color: BeerFloat | None = element(tag="COLOR", default=None)
+    version: BeerInt | None = element(tag="VERSION", default=None)
+    type: str | None = element(tag="TYPE", default=None)
+    origin: str | None = element(tag="ORIGIN", default=None)
+    supplier: str | None = element(tag="SUPPLIER", default=None)
+    notes: str | None = element(tag="NOTES", default=None)
+    coarse_fine_diff: BeerFloat | None = element(tag="COARSE_FINE_DIFF", default=None)
+    moisture: BeerFloat | None = element(tag="MOISTURE", default=None)
+    diastatic_power: BeerFloat | None = element(tag="DIASTATIC_POWER", default=None)
+    protein: BeerFloat | None = element(tag="PROTEIN", default=None)
+    max_in_batch: BeerFloat | None = element(tag="MAX_IN_BATCH", default=None)
+    ibu_gal_per_lb: BeerFloat | None = element(tag="IBU_GAL_PER_LB", default=None)
+    yield_pct: BeerFloat | None = element(tag="YIELD", default=None)
+    add_after_boil: BeerBool | None = element(tag="ADD_AFTER_BOIL", default=False)
+    recommend_mash: BeerBool | None = element(tag="RECOMMEND_MASH", default=None)
 
     @property
-    def add_after_boil(self) -> bool:
-        """Whether this fermentable is added after the boil (e.g. honey in secondary)."""
-        return bool(self._add_after_boil)
+    def _yield(self) -> float | None:
+        return self.yield_pct
 
-    @add_after_boil.setter
-    def add_after_boil(self, value: Any) -> None:
-        self._add_after_boil = cast_to_bool(value)
+    @_yield.setter
+    def _yield(self, value: float | int | str | None) -> None:
+        self.yield_pct = value
+
+    @property
+    def _add_after_boil(self) -> bool | None:
+        return self.add_after_boil
+
+    @_add_after_boil.setter
+    def _add_after_boil(self, value: bool | str | int | float | None) -> None:
+        self.add_after_boil = value
+
+    @property
+    def _recommend_mash(self) -> bool | None:
+        return self.recommend_mash
+
+    @_recommend_mash.setter
+    def _recommend_mash(self, value: bool | str | int | float | None) -> None:
+        self.recommend_mash = value
 
     @property
     def ppg(self) -> float | None:
@@ -71,8 +85,8 @@ class Fermentable:
 
         Returns ``None`` when ``YIELD`` is not set.
         """
-        if self._yield is not None:
-            return 0.46214 * self._yield
+        if self.yield_pct is not None:
+            return 0.46214 * self.yield_pct
         logger.error("Property 'ppg' could not be calculated because property 'yield' is missing. Default to 'None'")
         return None
 
@@ -123,12 +137,3 @@ class Fermentable:
         weight_lb = self.amount * 2.20462
         volume_gallons = liters * 0.264172
         return self.ppg * weight_lb / volume_gallons
-
-    @property
-    def recommend_mash(self) -> bool | None:
-        """Whether mashing is recommended for this fermentable."""
-        return self._recommend_mash
-
-    @recommend_mash.setter
-    def recommend_mash(self, value: Any) -> None:
-        self._recommend_mash = cast_to_bool(value)

--- a/pybeerxml/hop.py
+++ b/pybeerxml/hop.py
@@ -1,7 +1,11 @@
 import math
 
+from pydantic_xml import element
 
-class Hop:
+from pybeerxml.xml_model import BeerFloat, BeerInt, BeerXmlModel
+
+
+class Hop(BeerXmlModel, tag="HOP"):
     """A hop addition in a beer recipe.
 
     Attributes:
@@ -17,24 +21,23 @@ class Hop:
         notes: Free-text notes.
     """
 
-    def __init__(self):
-        self.name: str | None = None
-        self.alpha: float | None = None
-        self.amount: float | None = None
-        self.use: str | None = None
-        self.form: str | None = None
-        self.notes: str | None = None
-        self.time: float | None = None
-        self.version: int | None = None
-        self.type: str | None = None
-        self.beta: float | None = None
-        self.hsi: float | None = None
-        self.origin: str | None = None
-        self.substitutes: str | None = None
-        self.humulene: float | None = None
-        self.caryophyllene: float | None = None
-        self.cohumulone: float | None = None
-        self.myrcene: float | None = None
+    name: str | None = element(tag="NAME", default=None)
+    alpha: BeerFloat | None = element(tag="ALPHA", default=None)
+    amount: BeerFloat | None = element(tag="AMOUNT", default=None)
+    use: str | None = element(tag="USE", default=None)
+    form: str | None = element(tag="FORM", default=None)
+    notes: str | None = element(tag="NOTES", default=None)
+    time: BeerFloat | None = element(tag="TIME", default=None)
+    version: BeerInt | None = element(tag="VERSION", default=None)
+    type: str | None = element(tag="TYPE", default=None)
+    beta: BeerFloat | None = element(tag="BETA", default=None)
+    hsi: BeerFloat | None = element(tag="HSI", default=None)
+    origin: str | None = element(tag="ORIGIN", default=None)
+    substitutes: str | None = element(tag="SUBSTITUTES", default=None)
+    humulene: BeerFloat | None = element(tag="HUMULENE", default=None)
+    caryophyllene: BeerFloat | None = element(tag="CARYOPHYLLENE", default=None)
+    cohumulone: BeerFloat | None = element(tag="COHUMULONE", default=None)
+    myrcene: BeerFloat | None = element(tag="MYRCENE", default=None)
 
     def utilization_factor(self) -> float:
         """Utilization multiplier for hop form.

--- a/pybeerxml/mash.py
+++ b/pybeerxml/mash.py
@@ -1,16 +1,15 @@
-from dataclasses import dataclass, field
-from typing import Any
+from pydantic_xml import element, wrapped
 
 from pybeerxml.mash_step import MashStep
-from pybeerxml.utils import cast_to_bool
+from pybeerxml.xml_model import BeerBool, BeerFloat, BeerInt, BeerXmlModel, FloatOrStr
 
 
-@dataclass
-class Mash:
+class Mash(BeerXmlModel, tag="MASH"):
     """A mash profile, including temperature steps.
 
     Attributes:
         name: Profile name.
+        version: BeerXML mash profile version.
         grain_temp: Initial grain temperature in °C.
         sparge_temp: Sparge water temperature in °C.
         ph: Target mash pH.
@@ -21,23 +20,14 @@ class Mash:
         steps: Ordered list of mash temperature steps.
     """
 
-    name: str | None = None
-    version: int | None = None
-    grain_temp: float | None = None
-    sparge_temp: float | None = None
-    ph: float | None = None
-    notes: str | None = None
-    tun_temp: float | None = None
-    tun_weight: float | None = None
-    tun_specific_heat: float | None = None
-    steps: list[MashStep] = field(default_factory=list)
-    _equip_adjust: bool | None = field(default=None, init=False, repr=False)
-
-    @property
-    def equip_adjust(self) -> bool | None:
-        """Whether mash temperatures are adjusted for equipment heat capacity."""
-        return self._equip_adjust
-
-    @equip_adjust.setter
-    def equip_adjust(self, value: Any) -> None:
-        self._equip_adjust = cast_to_bool(value)
+    name: str | None = element(tag="NAME", default=None)
+    version: BeerInt | None = element(tag="VERSION", default=None)
+    grain_temp: FloatOrStr | None = element(tag="GRAIN_TEMP", default=None)
+    sparge_temp: BeerFloat | None = element(tag="SPARGE_TEMP", default=None)
+    ph: BeerFloat | None = element(tag="PH", default=None)
+    notes: str | None = element(tag="NOTES", default=None)
+    tun_temp: BeerFloat | None = element(tag="TUN_TEMP", default=None)
+    tun_weight: BeerFloat | None = element(tag="TUN_WEIGHT", default=None)
+    tun_specific_heat: BeerFloat | None = element(tag="TUN_SPECIFIC_HEAT", default=None)
+    equip_adjust: BeerBool | None = element(tag="EQUIP_ADJUST", default=None)
+    steps: list[MashStep] = wrapped("MASH_STEPS", element(tag="MASH_STEP", default_factory=list))

--- a/pybeerxml/mash_step.py
+++ b/pybeerxml/mash_step.py
@@ -1,4 +1,9 @@
-class MashStep:
+from pydantic_xml import element
+
+from pybeerxml.xml_model import BeerFloat, BeerInt, BeerXmlModel
+
+
+class MashStep(BeerXmlModel, tag="MASH_STEP"):
     """A single temperature step within a mash profile.
 
     Attributes:
@@ -11,15 +16,14 @@ class MashStep:
         decoction_amt: Volume of mash removed for decoction (decoction steps only).
     """
 
-    def __init__(self):
-        self.name: str | None = None
-        self.type: str | None = None
-        self.infuse_amount: float | None = None
-        self.step_temp: float | None = None
-        self.end_temp: float | None = None
-        self.step_time: float | None = None
-        self.decoction_amt: str | None = None
-        self.version: int | None = None
+    name: str | None = element(tag="NAME", default=None)
+    type: str | None = element(tag="TYPE", default=None)
+    infuse_amount: BeerFloat | None = element(tag="INFUSE_AMOUNT", default=None)
+    step_temp: BeerFloat | None = element(tag="STEP_TEMP", default=None)
+    end_temp: BeerFloat | None = element(tag="END_TEMP", default=None)
+    step_time: BeerFloat | None = element(tag="STEP_TIME", default=None)
+    decoction_amt: BeerFloat | None = element(tag="DECOCTION_AMOUNT", default=None)
+    version: BeerInt | None = element(tag="VERSION", default=None)
 
     @property
     def water_ratio(self):

--- a/pybeerxml/misc.py
+++ b/pybeerxml/misc.py
@@ -8,6 +8,7 @@ class Misc:
 
     Attributes:
         name: Ingredient name.
+        version: BeerXML misc record version.
         type: Category — ``"Spice"``, ``"Fining"``, ``"Water Agent"``,
             ``"Herb"``, ``"Flavor"``, or ``"Other"``.
         amount: Quantity — weight in kg or volume in litres depending on
@@ -21,6 +22,7 @@ class Misc:
 
     def __init__(self):
         self.name: str | None = None
+        self.version: int | None = None
         self.type: str | None = None
         self.amount: float | None = None
         self._amount_is_weight: bool | None = False

--- a/pybeerxml/misc.py
+++ b/pybeerxml/misc.py
@@ -29,4 +29,3 @@ class Misc(BeerXmlModel, tag="MISC"):
     use_for: str | None = element(tag="USE_FOR", default=None)
     time: BeerFloat | None = element(tag="TIME", default=None)
     notes: str | None = element(tag="NOTES", default=None)
-

--- a/pybeerxml/misc.py
+++ b/pybeerxml/misc.py
@@ -1,9 +1,9 @@
-from typing import Any
+from pydantic_xml import element
 
-from pybeerxml.utils import cast_to_bool
+from pybeerxml.xml_model import BeerBool, BeerFloat, BeerInt, BeerXmlModel
 
 
-class Misc:
+class Misc(BeerXmlModel, tag="MISC"):
     """A miscellaneous ingredient — finings, spices, water agents, etc.
 
     Attributes:
@@ -20,22 +20,13 @@ class Misc:
         notes: Free-text notes.
     """
 
-    def __init__(self):
-        self.name: str | None = None
-        self.version: int | None = None
-        self.type: str | None = None
-        self.amount: float | None = None
-        self._amount_is_weight: bool | None = False
-        self.use: str | None = None
-        self.use_for: str | None = None
-        self.time: float | None = None
-        self.notes: str | None = None
+    name: str | None = element(tag="NAME", default=None)
+    version: BeerInt | None = element(tag="VERSION", default=None)
+    type: str | None = element(tag="TYPE", default=None)
+    amount: BeerFloat | None = element(tag="AMOUNT", default=None)
+    amount_is_weight: BeerBool | None = element(tag="AMOUNT_IS_WEIGHT", default=False)
+    use: str | None = element(tag="USE", default=None)
+    use_for: str | None = element(tag="USE_FOR", default=None)
+    time: BeerFloat | None = element(tag="TIME", default=None)
+    notes: str | None = element(tag="NOTES", default=None)
 
-    @property
-    def amount_is_weight(self) -> bool | None:
-        """``True`` if ``amount`` is measured by weight (kg), ``False`` if by volume (L)."""
-        return self._amount_is_weight
-
-    @amount_is_weight.setter
-    def amount_is_weight(self, value: Any):
-        self._amount_is_weight = cast_to_bool(value)

--- a/pybeerxml/parser.py
+++ b/pybeerxml/parser.py
@@ -30,7 +30,8 @@ class Parser:
 
     A single BeerXML document may contain multiple `<RECIPE>` elements; all
     three parse methods always return a list. Unknown XML fields are logged at
-    ``ERROR`` level and silently ignored so that non-standard files do not raise.
+    ``ERROR`` level and silently ignored so that non-standard files do not
+    raise.
 
     Examples:
         >>> from pybeerxml import Parser
@@ -40,11 +41,28 @@ class Parser:
         ...     print(recipe.name, recipe.og)
     """
 
+    
     def parse_from_string(self, xml_string: str) -> list[Recipe]:
-        """Parse BeerXML content from a string."""
+        """Parse BeerXML content from a string.
+
+        Args:
+            xml_string: A valid BeerXML document as a string.
+
+        Returns:
+            A list of `Recipe` objects found in the document.
+        """
         return RecipesDocument.from_xml(xml_string).recipes
 
     def parse(self, xml_file: str) -> list[Recipe]:
-        """Parse a BeerXML file from disk."""
+        """Parse a BeerXML file from disk.
+
+        Args:
+            xml_file: Path to the `.beerxml` file.
+
+        Returns:
+            A list of `Recipe` objects found in the file.
+        """
         with open(xml_file, "rt") as file:
             return self.parse_from_string(file.read())
+
+    

--- a/pybeerxml/parser.py
+++ b/pybeerxml/parser.py
@@ -1,9 +1,6 @@
 from __future__ import annotations
 
 import logging
-from typing import Any
-from xml.etree import ElementTree
-from xml.etree.ElementTree import Element
 
 from pybeerxml.document import RecipesDocument
 from pybeerxml.equipment import Equipment
@@ -14,7 +11,6 @@ from pybeerxml.mash_step import MashStep
 from pybeerxml.misc import Misc
 from pybeerxml.recipe import Recipe
 from pybeerxml.style import Style
-from pybeerxml.utils import to_lower
 from pybeerxml.water import Water
 from pybeerxml.yeast import Yeast
 
@@ -41,7 +37,6 @@ class Parser:
         ...     print(recipe.name, recipe.og)
     """
 
-    
     def parse_from_string(self, xml_string: str) -> list[Recipe]:
         """Parse BeerXML content from a string.
 
@@ -64,5 +59,3 @@ class Parser:
         """
         with open(xml_file, "rt") as file:
             return self.parse_from_string(file.read())
-
-    

--- a/pybeerxml/parser.py
+++ b/pybeerxml/parser.py
@@ -20,6 +20,8 @@ from pybeerxml.yeast import Yeast
 logger = logging.getLogger(__name__)
 
 BeerXMLObject = Recipe | Mash | Yeast | Fermentable | Hop | Misc | MashStep | Style | Water | Equipment
+INTEGER_FIELDS = {"version", "fermentation_stages", "times_cultured", "max_reuse"}
+TEXT_FIELDS = {"category_number"}
 
 
 class Parser:
@@ -62,13 +64,24 @@ class Parser:
         attribute = to_lower(node.tag)
         attribute = "_yield" if attribute == "yield" else attribute
 
-        value: str | float | None = node.text or None
+        value: str | float | int | None = node.text or None
 
         if value is not None:
-            try:
-                value = float(value)
-            except ValueError:
+            if attribute in TEXT_FIELDS:
                 pass
+            elif attribute in INTEGER_FIELDS:
+                try:
+                    value = int(value)
+                except ValueError:
+                    try:
+                        value = int(float(value))
+                    except ValueError:
+                        pass
+            else:
+                try:
+                    value = float(value)
+                except ValueError:
+                    pass
 
             try:
                 setattr(beerxml_object, attribute, value)

--- a/pybeerxml/parser.py
+++ b/pybeerxml/parser.py
@@ -5,6 +5,7 @@ from typing import Any
 from xml.etree import ElementTree
 from xml.etree.ElementTree import Element
 
+from pybeerxml.document import RecipesDocument
 from pybeerxml.equipment import Equipment
 from pybeerxml.fermentable import Fermentable
 from pybeerxml.hop import Hop
@@ -28,7 +29,7 @@ class Parser:
     """Reads BeerXML files or strings and returns a list of `Recipe` objects.
 
     A single BeerXML document may contain multiple `<RECIPE>` elements; all
-    three parse methods always return a list.  Unknown XML fields are logged at
+    three parse methods always return a list. Unknown XML fields are logged at
     ``ERROR`` level and silently ignored so that non-standard files do not raise.
 
     Examples:
@@ -39,174 +40,11 @@ class Parser:
         ...     print(recipe.name, recipe.og)
     """
 
-    def nodes_to_object(self, nodes: Element, beerxml_object: BeerXMLObject) -> None:
-        """Map all child XML nodes onto an object's attributes.
-
-        Args:
-            nodes: Parent XML element whose children will be mapped.
-            beerxml_object: Target object to receive the attribute values.
-        """
-        for node in nodes:
-            self.node_to_object(node, beerxml_object)
-
-    def node_to_object(self, node: Element, beerxml_object: BeerXMLObject) -> None:
-        """Map a single XML node onto an object attribute.
-
-        The node tag is lower-cased and used as the attribute name.  Numeric
-        string values are coerced to ``float`` automatically.  The BeerXML
-        field ``YIELD`` is mapped to ``_yield`` because ``yield`` is a Python
-        keyword.
-
-        Args:
-            node: XML element to map.
-            beerxml_object: Target object to receive the attribute value.
-        """
-        attribute = to_lower(node.tag)
-        attribute = "_yield" if attribute == "yield" else attribute
-
-        value: str | float | int | None = node.text or None
-
-        if value is not None:
-            if attribute in TEXT_FIELDS:
-                pass
-            elif attribute in INTEGER_FIELDS:
-                try:
-                    value = int(value)
-                except ValueError:
-                    try:
-                        value = int(float(value))
-                    except ValueError:
-                        pass
-            else:
-                try:
-                    value = float(value)
-                except ValueError:
-                    pass
-
-            try:
-                setattr(beerxml_object, attribute, value)
-            except AttributeError:
-                logger.error("Attribute %s not supported.", attribute)
-
     def parse_from_string(self, xml_string: str) -> list[Recipe]:
-        """Parse BeerXML content from a string.
-
-        Args:
-            xml_string: A valid BeerXML document as a string.
-
-        Returns:
-            A list of `Recipe` objects found in the document.
-
-        Raises:
-            xml.etree.ElementTree.ParseError: If ``xml_string`` is not valid XML.
-        """
-        tree = ElementTree.ElementTree(ElementTree.fromstring(xml_string))
-        return self.parse_tree(tree)
+        """Parse BeerXML content from a string."""
+        return RecipesDocument.from_xml(xml_string).recipes
 
     def parse(self, xml_file: str) -> list[Recipe]:
-        """Parse a BeerXML file from disk.
-
-        Args:
-            xml_file: Path to the ``.beerxml`` file.
-
-        Returns:
-            A list of `Recipe` objects found in the file.
-
-        Raises:
-            FileNotFoundError: If ``xml_file`` does not exist.
-            xml.etree.ElementTree.ParseError: If the file is not valid XML.
-        """
+        """Parse a BeerXML file from disk."""
         with open(xml_file, "rt") as file:
-            tree = ElementTree.parse(file)
-        return self.parse_tree(tree)
-
-    def parse_tree(self, tree: ElementTree.ElementTree[Any]) -> list[Recipe]:
-        """Parse an already-constructed ``ElementTree``.
-
-        Useful when you need full control over XML loading (e.g. custom
-        encoding handling).
-
-        Args:
-            tree: A parsed XML tree.
-
-        Returns:
-            A list of `Recipe` objects found in the tree.
-        """
-        recipes = []
-        for recipe_node in tree.iter():
-            if to_lower(recipe_node.tag) != "recipe":
-                continue
-            recipe = self.parse_recipe(recipe_node)
-            recipes.append(recipe)
-        return recipes
-
-    def parse_recipe(self, recipe_node: Element) -> Recipe:
-        """Parse a single ``<RECIPE>`` element into a `Recipe` object.
-
-        Args:
-            recipe_node: The ``<RECIPE>`` XML element.
-
-        Returns:
-            A populated `Recipe` instance.
-        """
-        recipe = Recipe()
-
-        for recipe_property in recipe_node:
-            tag_name = to_lower(recipe_property.tag)
-
-            if tag_name == "fermentables":
-                for fermentable_node in recipe_property:
-                    fermentable = Fermentable()
-                    self.nodes_to_object(fermentable_node, fermentable)
-                    recipe.fermentables.append(fermentable)
-
-            elif tag_name == "yeasts":
-                for yeast_node in recipe_property:
-                    yeast = Yeast()
-                    self.nodes_to_object(yeast_node, yeast)
-                    recipe.yeasts.append(yeast)
-
-            elif tag_name == "hops":
-                for hop_node in recipe_property:
-                    hop = Hop()
-                    self.nodes_to_object(hop_node, hop)
-                    recipe.hops.append(hop)
-
-            elif tag_name == "miscs":
-                for misc_node in recipe_property:
-                    misc = Misc()
-                    self.nodes_to_object(misc_node, misc)
-                    recipe.miscs.append(misc)
-
-            elif tag_name == "style":
-                style = Style()
-                recipe.style = style
-                self.nodes_to_object(recipe_property, style)
-
-            elif tag_name == "waters":
-                for water_node in recipe_property:
-                    water = Water()
-                    self.nodes_to_object(water_node, water)
-                    recipe.waters.append(water)
-
-            elif tag_name == "equipment":
-                equipment = Equipment()
-                recipe.equipment = equipment
-                self.nodes_to_object(recipe_property, equipment)
-
-            elif tag_name == "mash":
-                mash = Mash()
-                recipe.mash = mash
-                for mash_node in recipe_property:
-                    if to_lower(mash_node.tag) == "mash_steps":
-                        for mash_step_node in mash_node:
-                            mash_step = MashStep()
-                            self.nodes_to_object(mash_step_node, mash_step)
-                            mash.steps.append(mash_step)
-                    else:
-                        self.node_to_object(mash_node, mash)
-
-            else:
-                self.node_to_object(recipe_property, recipe)
-
-        return recipe
+            return self.parse_from_string(file.read())

--- a/pybeerxml/recipe.py
+++ b/pybeerxml/recipe.py
@@ -11,7 +11,7 @@ from pybeerxml.misc import Misc
 from pybeerxml.style import Style
 from pybeerxml.utils import gravity_to_plato
 from pybeerxml.water import Water
-from pybeerxml.xml_model import BeerBool, BeerFloat, BeerInt, BeerXmlModel, FloatOrStr
+from pybeerxml.xml_model import BeerBool, BeerFloat, BeerInt, BeerXmlModel, FloatOrStr, coerce_float
 from pybeerxml.yeast import Yeast
 
 logger = logging.getLogger(__name__)
@@ -117,7 +117,7 @@ class Recipe(BeerXmlModel, tag="RECIPE"):
 
     @_abv.setter
     def _abv(self, value: float | int | str | None) -> None:
-        self.abv_value = value
+        self.abv_value = coerce_float(value)
 
     @property
     def _og(self) -> float | None:
@@ -125,7 +125,7 @@ class Recipe(BeerXmlModel, tag="RECIPE"):
 
     @_og.setter
     def _og(self, value: float | int | str | None) -> None:
-        self.og_value = value
+        self.og_value = coerce_float(value)
 
     @property
     def _fg(self) -> float | None:
@@ -133,7 +133,7 @@ class Recipe(BeerXmlModel, tag="RECIPE"):
 
     @_fg.setter
     def _fg(self, value: float | int | str | None) -> None:
-        self.fg_value = value
+        self.fg_value = coerce_float(value)
 
     @property
     def _ibu(self) -> float | None:
@@ -141,7 +141,7 @@ class Recipe(BeerXmlModel, tag="RECIPE"):
 
     @_ibu.setter
     def _ibu(self, value: float | int | str | None) -> None:
-        self.ibu_value = value
+        self.ibu_value = coerce_float(value)
 
     @property
     def _color(self) -> float | None:
@@ -149,7 +149,7 @@ class Recipe(BeerXmlModel, tag="RECIPE"):
 
     @_color.setter
     def _color(self, value: float | int | str | None) -> None:
-        self.color_value = value
+        self.color_value = coerce_float(value)
 
     @property
     def abv(self):

--- a/pybeerxml/recipe.py
+++ b/pybeerxml/recipe.py
@@ -57,7 +57,7 @@ class Recipe:
 
     def __init__(self):
         self.name: str | None = None
-        self.version: float | None = None
+        self.version: int | None = None
         self.type: str | None = None
         self.brewer: str | None = None
         self.asst_brewer: str | None = None

--- a/pybeerxml/recipe.py
+++ b/pybeerxml/recipe.py
@@ -372,18 +372,18 @@ class Recipe(BeerXmlModel, tag="RECIPE"):
 
     def to_xml_element(self) -> Element:
         """Serialize this recipe as a BeerXML ``<RECIPE>`` element."""
-        from pybeerxml.serializer import recipe_to_xml_element
+        from pybeerxml.serializer import Serializer
 
-        return recipe_to_xml_element(self)
+        return Serializer().recipe_to_xml_element(self)
 
     def to_xml_string(self, encoding: str = "utf-8", xml_declaration: bool = True) -> str:
         """Serialize this recipe as a complete BeerXML document string."""
-        from pybeerxml.serializer import serialize
+        from pybeerxml.serializer import Serializer
 
-        return serialize([self], encoding=encoding, xml_declaration=xml_declaration)
+        return Serializer().serialize([self], encoding=encoding, xml_declaration=xml_declaration)
 
     def write_xml(self, path: str, encoding: str = "utf-8") -> None:
         """Write this recipe as a complete BeerXML document to disk."""
-        from pybeerxml.serializer import write
+        from pybeerxml.serializer import Serializer
 
-        write([self], path=path, encoding=encoding)
+        Serializer().write([self], path=path, encoding=encoding)

--- a/pybeerxml/recipe.py
+++ b/pybeerxml/recipe.py
@@ -1,5 +1,7 @@
 import logging
-from typing import Any
+from xml.etree.ElementTree import Element
+
+from pydantic_xml import element, wrapped
 
 from pybeerxml.equipment import Equipment
 from pybeerxml.fermentable import Fermentable
@@ -7,14 +9,15 @@ from pybeerxml.hop import Hop
 from pybeerxml.mash import Mash
 from pybeerxml.misc import Misc
 from pybeerxml.style import Style
-from pybeerxml.utils import cast_to_bool, gravity_to_plato
+from pybeerxml.utils import gravity_to_plato
 from pybeerxml.water import Water
+from pybeerxml.xml_model import BeerBool, BeerFloat, BeerInt, BeerXmlModel, FloatOrStr
 from pybeerxml.yeast import Yeast
 
 logger = logging.getLogger(__name__)
 
 
-class Recipe:
+class Recipe(BeerXmlModel, tag="RECIPE"):
     """A complete beer recipe parsed from a BeerXML document.
 
     Scalar fields (``name``, ``batch_size``, etc.) are populated directly from
@@ -31,6 +34,7 @@ class Recipe:
 
     Attributes:
         name: Recipe name.
+        version: BeerXML recipe record version.
         brewer: Brewer's name.
         type: Recipe type, e.g. ``"All Grain"`` or ``"Extract"``.
         batch_size: Target batch volume in litres.
@@ -55,61 +59,98 @@ class Recipe:
         Simcoe IPA 1.0756 64.3
     """
 
-    def __init__(self):
-        self.name: str | None = None
-        self.version: int | None = None
-        self.type: str | None = None
-        self.brewer: str | None = None
-        self.asst_brewer: str | None = None
-        self.batch_size: float | None = None
-        self.boil_time: float | None = None
-        self.boil_size: float | None = None
-        self.efficiency: float | None = None
-        self.notes: str | None = None
-        self.taste_notes: str | None = None
-        self.taste_rating: float | None = None
-        self.fermentation_stages: int | None = None
-        self.primary_age: float | None = None
-        self.primary_temp: float | None = None
-        self.secondary_age: float | None = None
-        self.secondary_temp: float | None = None
-        self.tertiary_age: float | None = None
-        self.tertiary_temp: float | None = None
-        self.carbonation: float | None = None
-        self.carbonation_temp: float | None = None
-        self.age: float | None = None
-        self.age_temp: float | None = None
-        self.date: str | None = None
-        self._forced_carbonation: bool | None = None
-        self.priming_sugar_name: str | None = None
-        self.priming_sugar_equiv: float | None = None
-        self.keg_priming_factor: float | None = None
+    name: str | None = element(tag="NAME", default=None)
+    version: BeerInt | None = element(tag="VERSION", default=None)
+    type: str | None = element(tag="TYPE", default=None)
+    brewer: str | None = element(tag="BREWER", default=None)
+    asst_brewer: str | None = element(tag="ASST_BREWER", default=None)
+    batch_size: BeerFloat | None = element(tag="BATCH_SIZE", default=None)
+    boil_time: BeerFloat | None = element(tag="BOIL_TIME", default=None)
+    boil_size: BeerFloat | None = element(tag="BOIL_SIZE", default=None)
+    efficiency: BeerFloat | None = element(tag="EFFICIENCY", default=None)
+    notes: str | None = element(tag="NOTES", default=None)
+    taste_notes: str | None = element(tag="TASTE_NOTES", default=None)
+    taste_rating: BeerFloat | None = element(tag="TASTE_RATING", default=None)
+    fermentation_stages: BeerInt | None = element(tag="FERMENTATION_STAGES", default=None)
+    primary_age: BeerFloat | None = element(tag="PRIMARY_AGE", default=None)
+    primary_temp: BeerFloat | None = element(tag="PRIMARY_TEMP", default=None)
+    secondary_age: BeerFloat | None = element(tag="SECONDARY_AGE", default=None)
+    secondary_temp: BeerFloat | None = element(tag="SECONDARY_TEMP", default=None)
+    tertiary_age: BeerFloat | None = element(tag="TERTIARY_AGE", default=None)
+    tertiary_temp: BeerFloat | None = element(tag="TERTIARY_TEMP", default=None)
+    carbonation: BeerFloat | None = element(tag="CARBONATION", default=None)
+    carbonation_temp: BeerFloat | None = element(tag="CARBONATION_TEMP", default=None)
+    age: BeerFloat | None = element(tag="AGE", default=None)
+    age_temp: BeerFloat | None = element(tag="AGE_TEMP", default=None)
+    date: str | None = element(tag="DATE", default=None)
+    priming_sugar_name: str | None = element(tag="PRIMING_SUGAR_NAME", default=None)
+    priming_sugar_equiv: BeerFloat | None = element(tag="PRIMING_SUGAR_EQUIV", default=None)
+    keg_priming_factor: BeerFloat | None = element(tag="KEG_PRIMING_FACTOR", default=None)
+    est_og: BeerFloat | None = element(tag="EST_OG", default=None)
+    est_fg: BeerFloat | None = element(tag="EST_FG", default=None)
+    est_color: FloatOrStr | None = element(tag="EST_COLOR", default=None)
+    ibu_method: str | None = element(tag="IBU_METHOD", default=None)
+    est_abv: BeerFloat | None = element(tag="EST_ABV", default=None)
+    actual_efficiency: BeerFloat | None = element(tag="ACTUAL_EFFICIENCY", default=None)
+    calories: str | None = element(tag="CALORIES", default=None)
+    carbonation_used: str | None = element(tag="CARBONATION_USED", default=None)
 
-        # Recipe extension fields
-        self.est_og: float | None = None
-        self.est_fg: float | None = None
-        self.est_color: float | None = None
-        self.ibu_method: str | None = None
-        self.est_abv: float | None = None
-        self.actual_efficiency: float | None = None
-        self.calories: str | None = None
-        self.carbonation_used: str | None = None
+    og_value: BeerFloat | None = element(tag="OG", default=None)
+    fg_value: BeerFloat | None = element(tag="FG", default=None)
+    ibu_value: BeerFloat | None = element(tag="IBU", default=None)
+    abv_value: BeerFloat | None = element(tag="ABV", default=None)
+    color_value: BeerFloat | None = element(tag="COLOR", default=None)
+    forced_carbonation: BeerBool | None = element(tag="FORCED_CARBONATION", default=None)
 
-        # Values from the recipe, which are calculated as a fallback
-        self._abv: float | None = None
-        self._og: float | None = None
-        self._fg: float | None = None
-        self._ibu: float | None = None
-        self._color: float | None = None
+    style: Style | None = element(tag="STYLE", default=None)
+    hops: list[Hop] = wrapped("HOPS", element(tag="HOP", default_factory=list))
+    yeasts: list[Yeast] = wrapped("YEASTS", element(tag="YEAST", default_factory=list))
+    fermentables: list[Fermentable] = wrapped("FERMENTABLES", element(tag="FERMENTABLE", default_factory=list))
+    miscs: list[Misc] = wrapped("MISCS", element(tag="MISC", default_factory=list))
+    mash: Mash | None = element(tag="MASH", default=None)
+    waters: list[Water] = wrapped("WATERS", element(tag="WATER", default_factory=list))
+    equipment: Equipment | None = element(tag="EQUIPMENT", default=None)
 
-        self.style: Style | None = None
-        self.hops: list[Hop] = []
-        self.yeasts: list[Yeast] = []
-        self.fermentables: list[Fermentable] = []
-        self.miscs: list[Misc] = []
-        self.mash: Mash | None = None
-        self.waters: list[Water] = []
-        self.equipment: Equipment | None = None
+
+    @property
+    def _abv(self) -> float | None:
+        return self.abv_value
+
+    @_abv.setter
+    def _abv(self, value: float | int | str | None) -> None:
+        self.abv_value = value
+
+    @property
+    def _og(self) -> float | None:
+        return self.og_value
+
+    @_og.setter
+    def _og(self, value: float | int | str | None) -> None:
+        self.og_value = value
+
+    @property
+    def _fg(self) -> float | None:
+        return self.fg_value
+
+    @_fg.setter
+    def _fg(self, value: float | int | str | None) -> None:
+        self.fg_value = value
+
+    @property
+    def _ibu(self) -> float | None:
+        return self.ibu_value
+
+    @_ibu.setter
+    def _ibu(self, value: float | int | str | None) -> None:
+        self.ibu_value = value
+
+    @property
+    def _color(self) -> float | None:
+        return self.color_value
+
+    @_color.setter
+    def _color(self, value: float | int | str | None) -> None:
+        self.color_value = value
 
     @property
     def abv(self):
@@ -118,14 +159,14 @@ class Recipe:
         Returns the value stored in the XML when available, otherwise falls
         back to `abv_calculated`.
         """
-        if self._abv is not None:
-            return self._abv
+        if self.abv_value is not None:
+            return self.abv_value
         logger.debug("The value for ABV has been calculated from OG and FG")
         return self.abv_calculated
 
     @abv.setter
     def abv(self, value):
-        self._abv = value
+        self.abv_value = value
 
     @property
     def abv_calculated(self):
@@ -179,14 +220,14 @@ class Recipe:
         Returns the value stored in the XML when available, otherwise falls
         back to `ibu_calculated`.
         """
-        if self._ibu is not None:
-            return self._ibu
+        if self.ibu_value is not None:
+            return self.ibu_value
         logger.debug("The value for IBU has been calculated from the hop bill using Tinseth's formula")
         return self.ibu_calculated
 
     @ibu.setter
     def ibu(self, value):
-        self._ibu = value
+        self.ibu_value = value
 
     @property
     def ibu_calculated(self):
@@ -215,14 +256,14 @@ class Recipe:
         Returns the value stored in the XML when available, otherwise falls
         back to `og_calculated`.
         """
-        if self._og is not None:
-            return self._og
+        if self.og_value is not None:
+            return self.og_value
         logger.debug("The value for OG has been calculated from the mashing steps")
         return self.og_calculated
 
     @og.setter
     def og(self, value):
-        self._og = value
+        self.og_value = value
 
     @property
     def og_calculated(self):
@@ -266,14 +307,14 @@ class Recipe:
         Returns the value stored in the XML when available, otherwise falls
         back to `fg_calculated`.
         """
-        if self._fg is not None:
-            return self._fg
+        if self.fg_value is not None:
+            return self.fg_value
         logger.debug("The value for FG has been calculated from OG and yeast")
         return self.fg_calculated
 
     @fg.setter
     def fg(self, value):
-        self._fg = value
+        self.fg_value = value
 
     @property
     def fg_calculated(self):
@@ -301,14 +342,14 @@ class Recipe:
         Returns the value stored in the XML when available, otherwise falls
         back to `color_calculated`.
         """
-        if self._color is not None:
-            return self._color
+        if self.color_value is not None:
+            return self.color_value
         logger.debug("The value for color has been calculated from fermentables using the Morey Equation")
         return self.color_calculated
 
     @color.setter
     def color(self, value):
-        self._color = value
+        self.color_value = value
 
     @property
     def color_calculated(self):
@@ -329,11 +370,20 @@ class Recipe:
     def color_calculated(self, value):
         pass
 
-    @property
-    def forced_carbonation(self):
-        """Whether the beer is force-carbonated (``True``) or priming-sugar carbonated (``False``)."""
-        return self._forced_carbonation
+    def to_xml_element(self) -> Element:
+        """Serialize this recipe as a BeerXML ``<RECIPE>`` element."""
+        from pybeerxml.serializer import recipe_to_xml_element
 
-    @forced_carbonation.setter
-    def forced_carbonation(self, value: Any):
-        self._forced_carbonation = cast_to_bool(value)
+        return recipe_to_xml_element(self)
+
+    def to_xml_string(self, encoding: str = "utf-8", xml_declaration: bool = True) -> str:
+        """Serialize this recipe as a complete BeerXML document string."""
+        from pybeerxml.serializer import serialize
+
+        return serialize([self], encoding=encoding, xml_declaration=xml_declaration)
+
+    def write_xml(self, path: str, encoding: str = "utf-8") -> None:
+        """Write this recipe as a complete BeerXML document to disk."""
+        from pybeerxml.serializer import write
+
+        write([self], path=path, encoding=encoding)

--- a/pybeerxml/recipe.py
+++ b/pybeerxml/recipe.py
@@ -111,7 +111,6 @@ class Recipe(BeerXmlModel, tag="RECIPE"):
     waters: list[Water] = wrapped("WATERS", element(tag="WATER", default_factory=list))
     equipment: Equipment | None = element(tag="EQUIPMENT", default=None)
 
-
     @property
     def _abv(self) -> float | None:
         return self.abv_value

--- a/pybeerxml/serializer.py
+++ b/pybeerxml/serializer.py
@@ -51,6 +51,7 @@ class Serializer:
         root = document.to_xml_tree(skip_empty=True)
         for recipe_node in root.findall("RECIPE"):
             _ensure_required_recipe_sections(recipe_node)
+        ElementTree.indent(root, space="  ")
         xml = ElementTree.tostring(
             root,
             encoding=encoding if xml_declaration else "unicode",

--- a/pybeerxml/serializer.py
+++ b/pybeerxml/serializer.py
@@ -10,31 +10,68 @@ from pybeerxml.recipe import Recipe
 REQUIRED_RECIPE_SECTIONS = ("HOPS", "FERMENTABLES", "MISCS", "YEASTS", "WATERS")
 
 
-def recipe_to_xml_element(recipe: Recipe) -> Element:
-    element = recipe.to_xml_tree(skip_empty=True)
-    _ensure_required_recipe_sections(element)
-    return element
+class Serializer:
+    """Serialize `Recipe` objects into BeerXML.
 
+    The API mirrors `Parser` on the write side:
 
-def serialize(recipes: list[Recipe], encoding: str = "utf-8", xml_declaration: bool = True) -> str:
-    document = RecipesDocument(recipes=recipes)
-    root = document.to_xml_tree(skip_empty=True)
-    for recipe_node in root.findall("RECIPE"):
-        _ensure_required_recipe_sections(recipe_node)
-    xml = ElementTree.tostring(
-        root,
-        encoding=encoding if xml_declaration else "unicode",
-        xml_declaration=xml_declaration,
-    )
-    return xml if isinstance(xml, str) else xml.decode(encoding)
+    - `serialize()` returns a complete BeerXML document string
+    - `write()` writes a complete BeerXML document to disk
+    - `recipe_to_xml_element()` returns a single `<RECIPE>` element
 
+    BeerXML requires recipe record-set containers such as `HOPS` and
+    `FERMENTABLES`, so those sections are emitted even when empty.
+    """
 
-def write(recipes: list[Recipe], path: str, encoding: str = "utf-8") -> None:
-    xml = serialize(recipes, encoding=encoding, xml_declaration=True)
-    Path(path).write_text(xml, encoding=encoding)
+    def recipe_to_xml_element(self, recipe: Recipe) -> Element:
+        """Serialize a single recipe as a BeerXML `<RECIPE>` element.
+
+        Args:
+            recipe: The recipe to serialize.
+
+        Returns:
+            A single `<RECIPE>` XML element.
+        """
+        element = recipe.to_xml_tree(skip_empty=True)
+        _ensure_required_recipe_sections(element)
+        return element
+
+    def serialize(self, recipes: list[Recipe], encoding: str = "utf-8", xml_declaration: bool = True) -> str:
+        """Serialize recipes into a complete BeerXML document string.
+
+        Args:
+            recipes: Recipes to include in the document.
+            encoding: XML encoding to use for output.
+            xml_declaration: Whether to include the XML declaration.
+
+        Returns:
+            A BeerXML document as a string.
+        """
+        document = RecipesDocument(recipes=recipes)
+        root = document.to_xml_tree(skip_empty=True)
+        for recipe_node in root.findall("RECIPE"):
+            _ensure_required_recipe_sections(recipe_node)
+        xml = ElementTree.tostring(
+            root,
+            encoding=encoding if xml_declaration else "unicode",
+            xml_declaration=xml_declaration,
+        )
+        return xml if isinstance(xml, str) else xml.decode(encoding)
+
+    def write(self, recipes: list[Recipe], path: str, encoding: str = "utf-8") -> None:
+        """Write recipes to a BeerXML file.
+
+        Args:
+            recipes: Recipes to serialize.
+            path: Destination file path.
+            encoding: XML encoding to use for output.
+        """
+        xml = self.serialize(recipes, encoding=encoding, xml_declaration=True)
+        Path(path).write_text(xml, encoding=encoding)
 
 
 def _ensure_required_recipe_sections(recipe_element: Element) -> None:
+    """Ensure BeerXML-required recipe container tags are present."""
     for tag in REQUIRED_RECIPE_SECTIONS:
         if recipe_element.find(tag) is None:
             recipe_element.append(Element(tag))

--- a/pybeerxml/serializer.py
+++ b/pybeerxml/serializer.py
@@ -1,0 +1,40 @@
+from __future__ import annotations
+
+from pathlib import Path
+from xml.etree import ElementTree
+from xml.etree.ElementTree import Element
+
+from pybeerxml.document import RecipesDocument
+from pybeerxml.recipe import Recipe
+
+REQUIRED_RECIPE_SECTIONS = ("HOPS", "FERMENTABLES", "MISCS", "YEASTS", "WATERS")
+
+
+def recipe_to_xml_element(recipe: Recipe) -> Element:
+    element = recipe.to_xml_tree(skip_empty=True)
+    _ensure_required_recipe_sections(element)
+    return element
+
+
+def serialize(recipes: list[Recipe], encoding: str = "utf-8", xml_declaration: bool = True) -> str:
+    document = RecipesDocument(recipes=recipes)
+    root = document.to_xml_tree(skip_empty=True)
+    for recipe_node in root.findall("RECIPE"):
+        _ensure_required_recipe_sections(recipe_node)
+    xml = ElementTree.tostring(
+        root,
+        encoding=encoding if xml_declaration else "unicode",
+        xml_declaration=xml_declaration,
+    )
+    return xml if isinstance(xml, str) else xml.decode(encoding)
+
+
+def write(recipes: list[Recipe], path: str, encoding: str = "utf-8") -> None:
+    xml = serialize(recipes, encoding=encoding, xml_declaration=True)
+    Path(path).write_text(xml, encoding=encoding)
+
+
+def _ensure_required_recipe_sections(recipe_element: Element) -> None:
+    for tag in REQUIRED_RECIPE_SECTIONS:
+        if recipe_element.find(tag) is None:
+            recipe_element.append(Element(tag))

--- a/pybeerxml/style.py
+++ b/pybeerxml/style.py
@@ -1,8 +1,9 @@
-from dataclasses import dataclass
+from pydantic_xml import element
+
+from pybeerxml.xml_model import BeerFloat, BeerInt, BeerXmlModel
 
 
-@dataclass
-class Style:
+class Style(BeerXmlModel, tag="STYLE"):
     """Beer style guidelines from a BeerXML ``<STYLE>`` element.
 
     All ``_min`` / ``_max`` pairs define the acceptable range for that
@@ -31,23 +32,23 @@ class Style:
         notes: Free-text style notes.
     """
 
-    name: str | None = None
-    category: str | None = None
-    version: int | None = None
-    category_number: str | None = None
-    style_letter: str | None = None
-    style_guide: str | None = None
-    type: str | None = None
-    og_min: float | None = None
-    og_max: float | None = None
-    fg_min: float | None = None
-    fg_max: float | None = None
-    ibu_min: float | None = None
-    ibu_max: float | None = None
-    color_min: float | None = None
-    color_max: float | None = None
-    abv_min: float | None = None
-    abv_max: float | None = None
-    carb_min: float | None = None
-    carb_max: float | None = None
-    notes: str | None = None
+    name: str | None = element(tag="NAME", default=None)
+    category: str | None = element(tag="CATEGORY", default=None)
+    version: BeerInt | None = element(tag="VERSION", default=None)
+    category_number: str | None = element(tag="CATEGORY_NUMBER", default=None)
+    style_letter: str | None = element(tag="STYLE_LETTER", default=None)
+    style_guide: str | None = element(tag="STYLE_GUIDE", default=None)
+    type: str | None = element(tag="TYPE", default=None)
+    og_min: BeerFloat | None = element(tag="OG_MIN", default=None)
+    og_max: BeerFloat | None = element(tag="OG_MAX", default=None)
+    fg_min: BeerFloat | None = element(tag="FG_MIN", default=None)
+    fg_max: BeerFloat | None = element(tag="FG_MAX", default=None)
+    ibu_min: BeerFloat | None = element(tag="IBU_MIN", default=None)
+    ibu_max: BeerFloat | None = element(tag="IBU_MAX", default=None)
+    color_min: BeerFloat | None = element(tag="COLOR_MIN", default=None)
+    color_max: BeerFloat | None = element(tag="COLOR_MAX", default=None)
+    abv_min: BeerFloat | None = element(tag="ABV_MIN", default=None)
+    abv_max: BeerFloat | None = element(tag="ABV_MAX", default=None)
+    carb_min: BeerFloat | None = element(tag="CARB_MIN", default=None)
+    carb_max: BeerFloat | None = element(tag="CARB_MAX", default=None)
+    notes: str | None = element(tag="NOTES", default=None)

--- a/pybeerxml/style.py
+++ b/pybeerxml/style.py
@@ -11,6 +11,11 @@ class Style:
     Attributes:
         name: Style name (e.g. ``"American IPA"``).
         category: Style category (e.g. ``"India Pale Ale"``).
+        version: BeerXML style record version.
+        category_number: Style category identifier from the style guide.
+        style_letter: Style subcategory letter or identifier.
+        style_guide: Style guide name (e.g. ``"BJCP"``).
+        type: Beverage family (e.g. ``"Ale"``, ``"Lager"``, ``"Mead"``).
         og_min: Minimum original gravity.
         og_max: Maximum original gravity.
         fg_min: Minimum final gravity.
@@ -28,6 +33,11 @@ class Style:
 
     name: str | None = None
     category: str | None = None
+    version: int | None = None
+    category_number: str | None = None
+    style_letter: str | None = None
+    style_guide: str | None = None
+    type: str | None = None
     og_min: float | None = None
     og_max: float | None = None
     fg_min: float | None = None

--- a/pybeerxml/water.py
+++ b/pybeerxml/water.py
@@ -21,7 +21,7 @@ class Water:
     """
 
     name: str | None = None
-    version: float | None = None
+    version: int | None = None
     amount: float | None = None
     calcium: float | None = None
     bicarbonate: float | None = None

--- a/pybeerxml/water.py
+++ b/pybeerxml/water.py
@@ -1,14 +1,16 @@
-from dataclasses import dataclass
+from pydantic_xml import element
+
+from pybeerxml.xml_model import BeerFloat, BeerInt, BeerXmlModel
 
 
-@dataclass
-class Water:
+class Water(BeerXmlModel, tag="WATER"):
     """Water chemistry profile from a BeerXML ``<WATER>`` element.
 
     All ion concentrations are in parts per million (ppm / mg/L).
 
     Attributes:
         name: Water profile name (e.g. ``"Burton on Trent"``).
+        version: BeerXML water profile version.
         amount: Volume of water in litres.
         calcium: Calcium (Ca²⁺) concentration in ppm.
         bicarbonate: Bicarbonate (HCO₃⁻) concentration in ppm.
@@ -20,15 +22,15 @@ class Water:
         notes: Free-text notes.
     """
 
-    name: str | None = None
-    version: int | None = None
-    amount: float | None = None
-    calcium: float | None = None
-    bicarbonate: float | None = None
-    sulfate: float | None = None
-    chloride: float | None = None
-    sodium: float | None = None
-    magnesium: float | None = None
-    ph: float | None = None
-    notes: str | None = None
-    volume: float | None = None
+    name: str | None = element(tag="NAME", default=None)
+    version: BeerInt | None = element(tag="VERSION", default=None)
+    amount: BeerFloat | None = element(tag="AMOUNT", default=None)
+    calcium: BeerFloat | None = element(tag="CALCIUM", default=None)
+    bicarbonate: BeerFloat | None = element(tag="BICARBONATE", default=None)
+    sulfate: BeerFloat | None = element(tag="SULFATE", default=None)
+    chloride: BeerFloat | None = element(tag="CHLORIDE", default=None)
+    sodium: BeerFloat | None = element(tag="SODIUM", default=None)
+    magnesium: BeerFloat | None = element(tag="MAGNESIUM", default=None)
+    ph: BeerFloat | None = element(tag="PH", default=None)
+    notes: str | None = element(tag="NOTES", default=None)
+    volume: BeerFloat | None = element(tag="VOLUME", default=None)

--- a/pybeerxml/xml_model.py
+++ b/pybeerxml/xml_model.py
@@ -1,7 +1,7 @@
 from __future__ import annotations
 
 from decimal import Decimal
-from typing import Annotated, Any, ClassVar
+from typing import Annotated
 
 from pydantic import BeforeValidator, ConfigDict, PlainSerializer
 from pydantic_xml import BaseXmlModel
@@ -76,26 +76,12 @@ FloatOrStr = Annotated[
 
 
 class BeerXmlModel(BaseXmlModel, search_mode=SearchMode.UNORDERED):
-    """Base XML model with BeerXML-friendly parsing and assignment behavior."""
+    """Base XML model with BeerXML-friendly scalar parsing.
+
+    Model-specific compatibility aliases such as ``_yield`` or ``_og`` are
+    implemented on the individual model classes where they are needed. Keeping
+    those shims local avoids a global ``__setattr__``/``__getattr__`` hook that
+    would otherwise interfere with normal descriptor and property behavior.
+    """
 
     model_config = ConfigDict(extra="ignore", validate_assignment=True)
-    _compat_field_aliases: ClassVar[dict[str, str]] = {
-        "_yield": "yield_pct",
-        "_og": "og_value",
-        "_fg": "fg_value",
-        "_ibu": "ibu_value",
-        "_abv": "abv_value",
-        "_color": "color_value",
-    }
-
-    def __getattr__(self, item: str) -> Any:
-        alias = self._compat_field_aliases.get(item)
-        if alias is not None:
-            return super().__getattribute__(alias)
-        raise AttributeError(f"{type(self).__name__!r} object has no attribute {item!r}")
-
-    def __setattr__(self, key: str, value: Any) -> None:
-        alias = self._compat_field_aliases.get(key)
-        if alias is not None:
-            return super().__setattr__(alias, value)
-        return super().__setattr__(key, value)

--- a/pybeerxml/xml_model.py
+++ b/pybeerxml/xml_model.py
@@ -1,0 +1,86 @@
+from __future__ import annotations
+
+from decimal import Decimal
+from typing import Annotated, Any, ClassVar
+
+from pydantic import BeforeValidator, ConfigDict, PlainSerializer
+from pydantic_xml import BaseXmlModel
+
+from pybeerxml.utils import cast_to_bool
+
+
+def _serialize_beer_int(value: int) -> str:
+    return str(value)
+
+
+def _serialize_beer_float(value: float) -> str:
+    text = format(Decimal(str(value)), "f")
+    return text.rstrip("0").rstrip(".") or "0"
+
+
+def _serialize_beer_bool(value: bool) -> str:
+    return "TRUE" if value else "FALSE"
+
+
+def _parse_int_or_str(value: object) -> object:
+    if isinstance(value, str):
+        try:
+            return int(value)
+        except ValueError:
+            return value
+    return value
+
+
+def _parse_float_or_str(value: object) -> object:
+    if isinstance(value, str):
+        try:
+            return float(value)
+        except ValueError:
+            return value
+    return value
+
+
+BeerInt = Annotated[int, PlainSerializer(_serialize_beer_int, return_type=str)]
+BeerFloat = Annotated[float, PlainSerializer(_serialize_beer_float, return_type=str)]
+BeerBool = Annotated[
+    bool,
+    BeforeValidator(cast_to_bool),
+    PlainSerializer(_serialize_beer_bool, return_type=str),
+]
+
+IntOrStr = Annotated[
+    int | str,
+    BeforeValidator(_parse_int_or_str),
+    PlainSerializer(lambda value: _serialize_beer_int(value) if isinstance(value, int) else value, return_type=str),
+]
+FloatOrStr = Annotated[
+    float | str,
+    BeforeValidator(_parse_float_or_str),
+    PlainSerializer(lambda value: _serialize_beer_float(value) if isinstance(value, float) else value, return_type=str),
+]
+
+
+class BeerXmlModel(BaseXmlModel, search_mode="unordered"):
+    """Base XML model with BeerXML-friendly parsing and assignment behavior."""
+
+    model_config = ConfigDict(extra="ignore", validate_assignment=True)
+    _compat_field_aliases: ClassVar[dict[str, str]] = {
+        "_yield": "yield_pct",
+        "_og": "og_value",
+        "_fg": "fg_value",
+        "_ibu": "ibu_value",
+        "_abv": "abv_value",
+        "_color": "color_value",
+    }
+
+    def __getattr__(self, item: str) -> Any:
+        alias = self._compat_field_aliases.get(item)
+        if alias is not None:
+            return super().__getattribute__(alias)
+        return super().__getattr__(item)
+
+    def __setattr__(self, key: str, value: Any) -> None:
+        alias = self._compat_field_aliases.get(key)
+        if alias is not None:
+            return super().__setattr__(alias, value)
+        return super().__setattr__(key, value)

--- a/pybeerxml/xml_model.py
+++ b/pybeerxml/xml_model.py
@@ -5,6 +5,7 @@ from typing import Annotated, Any, ClassVar
 
 from pydantic import BeforeValidator, ConfigDict, PlainSerializer
 from pydantic_xml import BaseXmlModel
+from pydantic_xml.element.element import SearchMode
 
 from pybeerxml.utils import cast_to_bool
 
@@ -40,6 +41,20 @@ def _parse_float_or_str(value: object) -> object:
     return value
 
 
+def coerce_bool(value: bool | str | int | float | None) -> bool | None:
+    """Coerce a BeerXML boolean-ish value to `bool | None`."""
+    if value is None:
+        return None
+    return cast_to_bool(value)
+
+
+def coerce_float(value: float | int | str | None) -> float | None:
+    """Coerce a BeerXML numeric value to `float | None`."""
+    if value is None:
+        return None
+    return float(value)
+
+
 BeerInt = Annotated[int, PlainSerializer(_serialize_beer_int, return_type=str)]
 BeerFloat = Annotated[float, PlainSerializer(_serialize_beer_float, return_type=str)]
 BeerBool = Annotated[
@@ -60,7 +75,7 @@ FloatOrStr = Annotated[
 ]
 
 
-class BeerXmlModel(BaseXmlModel, search_mode="unordered"):
+class BeerXmlModel(BaseXmlModel, search_mode=SearchMode.UNORDERED):
     """Base XML model with BeerXML-friendly parsing and assignment behavior."""
 
     model_config = ConfigDict(extra="ignore", validate_assignment=True)
@@ -77,7 +92,7 @@ class BeerXmlModel(BaseXmlModel, search_mode="unordered"):
         alias = self._compat_field_aliases.get(item)
         if alias is not None:
             return super().__getattribute__(alias)
-        return super().__getattr__(item)
+        raise AttributeError(f"{type(self).__name__!r} object has no attribute {item!r}")
 
     def __setattr__(self, key: str, value: Any) -> None:
         alias = self._compat_field_aliases.get(key)

--- a/pybeerxml/yeast.py
+++ b/pybeerxml/yeast.py
@@ -1,15 +1,14 @@
-from dataclasses import dataclass, field
-from typing import Any
+from pydantic_xml import element
 
-from pybeerxml.utils import cast_to_bool
+from pybeerxml.xml_model import BeerBool, BeerFloat, BeerInt, BeerXmlModel, IntOrStr
 
 
-@dataclass
-class Yeast:
+class Yeast(BeerXmlModel, tag="YEAST"):
     """A yeast strain used in a recipe.
 
     Attributes:
         name: Yeast strain name.
+        version: BeerXML yeast record version.
         type: Yeast type — ``"Ale"``, ``"Lager"``, ``"Wheat"``, ``"Wine"``, or ``"Champagne"``.
         form: Physical form — ``"Liquid"``, ``"Dry"``, ``"Slant"``, or ``"Culture"``.
         attenuation: Apparent attenuation percentage.
@@ -23,40 +22,22 @@ class Yeast:
         notes: Free-text notes.
     """
 
-    name: str | None = None
-    version: int | None = None
-    type: str | None = None
-    form: str | None = None
-    attenuation: float | None = None
-    notes: str | None = None
-    laboratory: str | None = None
-    product_id: str | None = None
-    flocculation: str | None = None
-    amount: float | None = None
-    min_temperature: float | None = None
-    max_temperature: float | None = None
-    best_for: str | None = None
-    times_cultured: int | None = None
-    max_reuse: int | None = None
-    inventory: str | None = None
-    culture_date: str | None = None
-    _amount_is_weight: bool | None = field(default=None, init=False, repr=False)
-    _add_to_secondary: bool | None = field(default=None, init=False, repr=False)
-
-    @property
-    def amount_is_weight(self) -> bool | None:
-        """``True`` if ``amount`` is measured by weight (kg), ``False`` if by volume (L)."""
-        return self._amount_is_weight
-
-    @amount_is_weight.setter
-    def amount_is_weight(self, value: Any) -> None:
-        self._amount_is_weight = cast_to_bool(value)
-
-    @property
-    def add_to_secondary(self) -> bool | None:
-        """``True`` if this yeast is pitched at the secondary fermentation stage."""
-        return self._add_to_secondary
-
-    @add_to_secondary.setter
-    def add_to_secondary(self, value: Any) -> None:
-        self._add_to_secondary = cast_to_bool(value)
+    name: str | None = element(tag="NAME", default=None)
+    version: BeerInt | None = element(tag="VERSION", default=None)
+    type: str | None = element(tag="TYPE", default=None)
+    form: str | None = element(tag="FORM", default=None)
+    attenuation: BeerFloat | None = element(tag="ATTENUATION", default=None)
+    notes: str | None = element(tag="NOTES", default=None)
+    laboratory: str | None = element(tag="LABORATORY", default=None)
+    product_id: IntOrStr | None = element(tag="PRODUCT_ID", default=None)
+    flocculation: str | None = element(tag="FLOCCULATION", default=None)
+    amount: BeerFloat | None = element(tag="AMOUNT", default=None)
+    min_temperature: BeerFloat | None = element(tag="MIN_TEMPERATURE", default=None)
+    max_temperature: BeerFloat | None = element(tag="MAX_TEMPERATURE", default=None)
+    best_for: str | None = element(tag="BEST_FOR", default=None)
+    times_cultured: BeerInt | None = element(tag="TIMES_CULTURED", default=None)
+    max_reuse: BeerInt | None = element(tag="MAX_REUSE", default=None)
+    inventory: str | None = element(tag="INVENTORY", default=None)
+    culture_date: str | None = element(tag="CULTURE_DATE", default=None)
+    amount_is_weight: BeerBool | None = element(tag="AMOUNT_IS_WEIGHT", default=None)
+    add_to_secondary: BeerBool | None = element(tag="ADD_TO_SECONDARY", default=None)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -7,6 +7,10 @@ license = { text = "MIT" }
 readme = "README.md"
 keywords = ["pybeerxml", "beerxml"]
 requires-python = ">=3.10"
+dependencies = [
+    "pydantic>=2.12.0,<3",
+    "pydantic-xml>=2.18.0,<3",
+]
 
 [project.urls]
 Repository = "https://github.com/hotzenklotz/pybeerxml/"

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -1,13 +1,10 @@
 # -*- coding: utf-8 -*-
 import os
 from math import floor
-from xml.etree.ElementTree import Element, SubElement
 
 from pybeerxml.equipment import Equipment
-from pybeerxml.hop import Hop
 from pybeerxml.mash import Mash
 from pybeerxml.parser import Parser, Recipe
-from pybeerxml.utils import to_lower
 
 RECIPE_PATH = os.path.join(os.path.dirname(__file__), "Simcoe IPA.xml")
 RECIPE_PATH_2 = os.path.join(os.path.dirname(__file__), "Oatmeal Stout.xml")
@@ -297,6 +294,7 @@ def assert_coffee_stout_recipe(recipes):
     assert recipe.yeasts[0].times_cultured == 1
     assert recipe.yeasts[0].max_reuse == 0
     assert not recipe.yeasts[0].add_to_secondary
+
 
 def test_parse_empty_recipe():
     xml = "<RECIPES><RECIPE><NAME>Empty</NAME></RECIPE></RECIPES>"

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -298,37 +298,6 @@ def assert_coffee_stout_recipe(recipes):
     assert recipe.yeasts[0].max_reuse == 0
     assert not recipe.yeasts[0].add_to_secondary
 
-
-def test_node_to_object():
-    "test XML node parsing to Python object"
-
-    node = Element("hop")
-    SubElement(node, "name").text = "Simcoe"
-    SubElement(node, "alpha").text = 13
-    SubElement(node, "amount").text = 0.5
-    SubElement(node, "use").text = "boil"
-    SubElement(node, "time").text = 30
-
-    test_hop = Hop()
-
-    recipe_parser = Parser()
-    recipe_parser.nodes_to_object(node, test_hop)
-
-    assert test_hop.name == "Simcoe"
-    assert test_hop.alpha == 13
-    assert test_hop.amount == 0.5
-    assert test_hop.use == "boil"
-    assert test_hop.time == 30
-
-
-def test_to_lower():
-
-    assert to_lower("MASH") == "mash"
-    assert to_lower("") == ""
-    assert to_lower(10) == ""
-    assert to_lower(None) == ""
-
-
 def test_parse_empty_recipe():
     xml = "<RECIPES><RECIPE><NAME>Empty</NAME></RECIPE></RECIPES>"
     recipes = Parser().parse_from_string(xml)

--- a/tests/test_serializer.py
+++ b/tests/test_serializer.py
@@ -403,6 +403,7 @@ def test_recipe_element_and_write_helpers(tmp_path):
     assert Parser().parse(str(single_path))[0].name == recipe.name
     assert len(Parser().parse(str(multiple_path))) == 2
 
+
 def test_serializer_class_writes_file(tmp_path):
     serializer = Serializer()
     recipes = [Parser().parse(RECIPE_PATH_1)[0]]

--- a/tests/test_serializer.py
+++ b/tests/test_serializer.py
@@ -1,0 +1,557 @@
+import os
+from xml.etree import ElementTree
+
+from pybeerxml import Parser, serialize, write
+from pybeerxml.fermentable import Fermentable
+from pybeerxml.hop import Hop
+from pybeerxml.misc import Misc
+from pybeerxml.recipe import Recipe
+from pybeerxml.yeast import Yeast
+
+RECIPE_PATH_1 = os.path.join(os.path.dirname(__file__), "Simcoe IPA.xml")
+RECIPE_PATH_2 = os.path.join(os.path.dirname(__file__), "Oatmeal Stout.xml")
+RECIPE_PATH_3 = os.path.join(os.path.dirname(__file__), "CoffeeStout.xml")
+
+
+RECIPE_FIELDS = (
+    "name",
+    "version",
+    "type",
+    "brewer",
+    "asst_brewer",
+    "batch_size",
+    "boil_size",
+    "boil_time",
+    "efficiency",
+    "notes",
+    "taste_notes",
+    "taste_rating",
+    "date",
+    "_og",
+    "_fg",
+    "_ibu",
+    "_abv",
+    "_color",
+    "fermentation_stages",
+    "primary_age",
+    "primary_temp",
+    "secondary_age",
+    "secondary_temp",
+    "tertiary_age",
+    "tertiary_temp",
+    "age",
+    "age_temp",
+    "carbonation",
+    "forced_carbonation",
+    "priming_sugar_name",
+    "carbonation_temp",
+    "priming_sugar_equiv",
+    "keg_priming_factor",
+    "est_og",
+    "est_fg",
+    "est_color",
+    "ibu_method",
+    "est_abv",
+    "actual_efficiency",
+    "calories",
+    "carbonation_used",
+)
+
+STYLE_FIELDS = (
+    "name",
+    "category",
+    "version",
+    "category_number",
+    "style_letter",
+    "style_guide",
+    "type",
+    "og_min",
+    "og_max",
+    "fg_min",
+    "fg_max",
+    "ibu_min",
+    "ibu_max",
+    "color_min",
+    "color_max",
+    "abv_min",
+    "abv_max",
+    "carb_min",
+    "carb_max",
+    "notes",
+)
+
+EQUIPMENT_FIELDS = (
+    "name",
+    "version",
+    "boil_size",
+    "batch_size",
+    "tun_volume",
+    "tun_weight",
+    "tun_specific_heat",
+    "top_up_water",
+    "trub_chiller_loss",
+    "evap_rate",
+    "boil_time",
+    "calc_boil_volume",
+    "lauter_deadspace",
+    "top_up_kettle",
+    "hop_utilization",
+    "notes",
+)
+
+HOP_FIELDS = (
+    "name",
+    "version",
+    "alpha",
+    "amount",
+    "use",
+    "time",
+    "notes",
+    "type",
+    "form",
+    "beta",
+    "hsi",
+    "origin",
+    "substitutes",
+    "humulene",
+    "caryophyllene",
+    "cohumulone",
+    "myrcene",
+)
+
+FERMENTABLE_FIELDS = (
+    "name",
+    "version",
+    "type",
+    "amount",
+    "_yield",
+    "color",
+    "add_after_boil",
+    "origin",
+    "supplier",
+    "notes",
+    "coarse_fine_diff",
+    "moisture",
+    "diastatic_power",
+    "protein",
+    "max_in_batch",
+    "recommend_mash",
+    "ibu_gal_per_lb",
+)
+
+MISC_FIELDS = (
+    "name",
+    "version",
+    "type",
+    "use",
+    "time",
+    "amount",
+    "amount_is_weight",
+    "use_for",
+    "notes",
+)
+
+YEAST_FIELDS = (
+    "name",
+    "version",
+    "type",
+    "form",
+    "amount",
+    "amount_is_weight",
+    "laboratory",
+    "product_id",
+    "min_temperature",
+    "max_temperature",
+    "flocculation",
+    "attenuation",
+    "notes",
+    "best_for",
+    "times_cultured",
+    "max_reuse",
+    "inventory",
+    "culture_date",
+    "add_to_secondary",
+)
+
+WATER_FIELDS = (
+    "name",
+    "version",
+    "amount",
+    "calcium",
+    "bicarbonate",
+    "sulfate",
+    "chloride",
+    "sodium",
+    "magnesium",
+    "ph",
+    "notes",
+    "volume",
+)
+
+MASH_FIELDS = (
+    "name",
+    "version",
+    "grain_temp",
+    "sparge_temp",
+    "ph",
+    "tun_temp",
+    "tun_weight",
+    "tun_specific_heat",
+    "equip_adjust",
+    "notes",
+)
+
+MASH_STEP_FIELDS = (
+    "name",
+    "version",
+    "type",
+    "infuse_amount",
+    "step_temp",
+    "step_time",
+    "end_temp",
+    "decoction_amt",
+)
+
+
+def _snapshot_fields(obj, fields):
+    if obj is None:
+        return None
+    return {field: getattr(obj, field) for field in fields}
+
+
+def _snapshot_recipe(recipe):
+    return {
+        "recipe": _snapshot_fields(recipe, RECIPE_FIELDS),
+        "style": _snapshot_fields(recipe.style, STYLE_FIELDS),
+        "equipment": _snapshot_fields(recipe.equipment, EQUIPMENT_FIELDS),
+        "hops": [_snapshot_fields(hop, HOP_FIELDS) for hop in recipe.hops],
+        "fermentables": [_snapshot_fields(fermentable, FERMENTABLE_FIELDS) for fermentable in recipe.fermentables],
+        "miscs": [_snapshot_fields(misc, MISC_FIELDS) for misc in recipe.miscs],
+        "yeasts": [_snapshot_fields(yeast, YEAST_FIELDS) for yeast in recipe.yeasts],
+        "waters": [_snapshot_fields(water, WATER_FIELDS) for water in recipe.waters],
+        "mash": {
+            "fields": _snapshot_fields(recipe.mash, MASH_FIELDS),
+            "steps": [_snapshot_fields(step, MASH_STEP_FIELDS) for step in (recipe.mash.steps if recipe.mash else [])],
+        },
+    }
+
+
+def test_roundtrip_simcoe_recipe():
+    parser = Parser()
+    recipe = parser.parse(RECIPE_PATH_1)[0]
+
+    xml = recipe.to_xml_string()
+    roundtripped = parser.parse_from_string(xml)[0]
+
+    assert _snapshot_recipe(roundtripped) == _snapshot_recipe(recipe)
+
+
+def test_roundtrip_oatmeal_stout_recipe():
+    parser = Parser()
+    recipe = parser.parse(RECIPE_PATH_2)[0]
+
+    xml = recipe.to_xml_string()
+    roundtripped = parser.parse_from_string(xml)[0]
+
+    assert _snapshot_recipe(roundtripped) == _snapshot_recipe(recipe)
+
+
+def test_roundtrip_coffee_stout_recipe():
+    parser = Parser()
+    recipe = parser.parse(RECIPE_PATH_3)[0]
+
+    xml = recipe.to_xml_string()
+    roundtripped = parser.parse_from_string(xml)[0]
+
+    assert _snapshot_recipe(roundtripped) == _snapshot_recipe(recipe)
+
+
+def test_serialize_multiple_recipes_in_one_document():
+    parser = Parser()
+    recipes = [parser.parse(RECIPE_PATH_1)[0], parser.parse(RECIPE_PATH_2)[0]]
+
+    xml = serialize(recipes)
+    tree = ElementTree.fromstring(xml)
+    roundtripped = parser.parse_from_string(xml)
+
+    assert tree.tag == "RECIPES"
+    assert len(tree.findall("RECIPE")) == 2
+    assert [recipe.name for recipe in roundtripped] == [recipe.name for recipe in recipes]
+
+
+def test_numeric_boolean_and_backing_field_serialization():
+    recipe = Recipe()
+    recipe.name = "Serialization Test"
+    recipe.version = 1
+    recipe.batch_size = 20.5
+    recipe.forced_carbonation = True
+
+    fermentable = Fermentable()
+    fermentable.name = "Pale Malt"
+    fermentable.version = 1
+    fermentable.amount = 5.25
+    fermentable._yield = 81.0
+    fermentable.color = 3.0
+    fermentable.add_after_boil = False
+    fermentable.recommend_mash = True
+    recipe.fermentables.append(fermentable)
+
+    misc = Misc()
+    misc.name = "Irish Moss"
+    misc.type = "Fining"
+    misc.amount = 0.01
+    misc.amount_is_weight = True
+    recipe.miscs.append(misc)
+
+    yeast = Yeast()
+    yeast.name = "US-05"
+    yeast.amount = 0.011
+    yeast.amount_is_weight = False
+    recipe.yeasts.append(yeast)
+
+    xml = recipe.to_xml_string()
+
+    assert "<VERSION>1</VERSION>" in xml
+    assert "<BATCH_SIZE>20.5</BATCH_SIZE>" in xml
+    assert "<FORCED_CARBONATION>TRUE</FORCED_CARBONATION>" in xml
+    assert "<YIELD>81</YIELD>" in xml
+    assert "<ADD_AFTER_BOIL>FALSE</ADD_AFTER_BOIL>" in xml
+    assert "<RECOMMEND_MASH>TRUE</RECOMMEND_MASH>" in xml
+    assert "<AMOUNT_IS_WEIGHT>TRUE</AMOUNT_IS_WEIGHT>" in xml
+    assert "<AMOUNT_IS_WEIGHT>FALSE</AMOUNT_IS_WEIGHT>" in xml
+
+
+def test_calculated_recipe_metrics_are_not_serialized_when_only_derived():
+    recipe = Recipe()
+    recipe.name = "Derived Metrics Only"
+    recipe.batch_size = 20.0
+
+    fermentable = Fermentable()
+    fermentable.name = "Pale Malt"
+    fermentable.amount = 5.0
+    fermentable._yield = 80.0
+    fermentable.color = 5.0
+    recipe.fermentables.append(fermentable)
+
+    hop = Hop()
+    hop.name = "Cascade"
+    hop.alpha = 6.0
+    hop.amount = 0.02
+    hop.use = "boil"
+    hop.time = 60.0
+    recipe.hops.append(hop)
+
+    yeast = Yeast()
+    yeast.name = "House Yeast"
+    yeast.attenuation = 75.0
+    recipe.yeasts.append(yeast)
+
+    assert recipe.og is not None
+    assert recipe.fg is not None
+    assert recipe.ibu is not None
+    assert recipe.abv is not None
+    assert recipe.color is not None
+
+    xml = recipe.to_xml_string()
+    recipe_node = ElementTree.fromstring(xml).find("RECIPE")
+    roundtripped = Parser().parse_from_string(xml)[0]
+
+    assert recipe_node is not None
+    assert recipe_node.find("OG") is None
+    assert recipe_node.find("FG") is None
+    assert recipe_node.find("IBU") is None
+    assert recipe_node.find("ABV") is None
+    assert recipe_node.find("COLOR") is None
+    assert roundtripped._og is None
+    assert roundtripped._fg is None
+    assert roundtripped._ibu is None
+    assert roundtripped._abv is None
+    assert roundtripped._color is None
+    assert round(roundtripped.og, 4) == round(recipe.og, 4)
+    assert round(roundtripped.fg, 4) == round(recipe.fg, 4)
+    assert round(roundtripped.ibu, 4) == round(recipe.ibu, 4)
+    assert round(roundtripped.abv, 4) == round(recipe.abv, 4)
+    assert round(roundtripped.color, 4) == round(recipe.color, 4)
+
+
+def test_empty_optional_sections_are_omitted():
+    recipe = Recipe()
+    recipe.name = "Bare Minimum"
+
+    xml = recipe.to_xml_string()
+
+    assert "<HOPS />" in xml or "<HOPS/>" in xml
+    assert "<FERMENTABLES />" in xml or "<FERMENTABLES/>" in xml
+    assert "<MISCS />" in xml or "<MISCS/>" in xml
+    assert "<YEASTS />" in xml or "<YEASTS/>" in xml
+    assert "<WATERS />" in xml or "<WATERS/>" in xml
+    assert "<MASH>" not in xml
+
+
+def test_recipe_element_and_write_helpers(tmp_path):
+    recipe = Parser().parse(RECIPE_PATH_1)[0]
+    single_path = tmp_path / "single.xml"
+    multiple_path = tmp_path / "multiple.xml"
+
+    recipe_element = recipe.to_xml_element()
+    recipe.write_xml(str(single_path))
+    write([recipe, Parser().parse(RECIPE_PATH_2)[0]], str(multiple_path))
+
+    assert recipe_element.tag == "RECIPE"
+    assert Parser().parse(str(single_path))[0].name == recipe.name
+    assert len(Parser().parse(str(multiple_path))) == 2
+
+
+def test_parser_preserves_integer_version_fields():
+    xml = """<?xml version="1.0" encoding="utf-8"?>
+<RECIPES>
+  <RECIPE>
+    <NAME>Version Test</NAME>
+    <VERSION>1</VERSION>
+    <TYPE>All Grain</TYPE>
+    <STYLE>
+      <NAME>Ordinary Bitter</NAME>
+      <CATEGORY>British Bitter</CATEGORY>
+      <VERSION>1</VERSION>
+      <CATEGORY_NUMBER>11</CATEGORY_NUMBER>
+      <STYLE_LETTER>A</STYLE_LETTER>
+      <STYLE_GUIDE>BJCP</STYLE_GUIDE>
+      <TYPE>Ale</TYPE>
+      <OG_MIN>1.030</OG_MIN>
+      <OG_MAX>1.039</OG_MAX>
+      <FG_MIN>1.007</FG_MIN>
+      <FG_MAX>1.011</FG_MAX>
+      <IBU_MIN>25</IBU_MIN>
+      <IBU_MAX>35</IBU_MAX>
+      <COLOR_MIN>4</COLOR_MIN>
+      <COLOR_MAX>14</COLOR_MAX>
+    </STYLE>
+    <BREWER>Tester</BREWER>
+    <BATCH_SIZE>20</BATCH_SIZE>
+    <BOIL_SIZE>25</BOIL_SIZE>
+    <BOIL_TIME>60</BOIL_TIME>
+    <EFFICIENCY>75</EFFICIENCY>
+    <HOPS />
+    <FERMENTABLES />
+    <MISCS>
+      <MISC>
+        <NAME>Irish Moss</NAME>
+        <VERSION>1</VERSION>
+        <TYPE>Fining</TYPE>
+        <USE>Boil</USE>
+        <TIME>15</TIME>
+        <AMOUNT>0.01</AMOUNT>
+      </MISC>
+    </MISCS>
+    <YEASTS />
+    <WATERS>
+      <WATER>
+        <NAME>RO Water</NAME>
+        <VERSION>1</VERSION>
+        <AMOUNT>20</AMOUNT>
+        <CALCIUM>0</CALCIUM>
+        <BICARBONATE>0</BICARBONATE>
+        <SULFATE>0</SULFATE>
+        <CHLORIDE>0</CHLORIDE>
+        <SODIUM>0</SODIUM>
+        <MAGNESIUM>0</MAGNESIUM>
+      </WATER>
+    </WATERS>
+    <MASH>
+      <NAME>Single Infusion</NAME>
+      <VERSION>1</VERSION>
+      <GRAIN_TEMP>22</GRAIN_TEMP>
+      <MASH_STEPS>
+        <MASH_STEP>
+          <NAME>Conversion</NAME>
+          <VERSION>1</VERSION>
+          <TYPE>Infusion</TYPE>
+          <INFUSE_AMOUNT>10</INFUSE_AMOUNT>
+          <STEP_TEMP>67</STEP_TEMP>
+          <STEP_TIME>60</STEP_TIME>
+        </MASH_STEP>
+      </MASH_STEPS>
+    </MASH>
+  </RECIPE>
+</RECIPES>
+"""
+    recipe = Parser().parse_from_string(xml)[0]
+
+    assert isinstance(recipe.version, int)
+    assert isinstance(recipe.style.version, int)
+    assert isinstance(recipe.miscs[0].version, int)
+    assert isinstance(recipe.waters[0].version, int)
+    assert isinstance(recipe.mash.version, int)
+    assert isinstance(recipe.mash.steps[0].version, int)
+
+
+def test_style_required_fields_roundtrip():
+    style_xml = """<?xml version="1.0" encoding="utf-8"?>
+<RECIPES>
+  <RECIPE>
+    <NAME>x</NAME>
+    <VERSION>1</VERSION>
+    <TYPE>All Grain</TYPE>
+    <STYLE>
+      <NAME>Dry Stout</NAME>
+      <CATEGORY>Stout</CATEGORY>
+      <VERSION>1</VERSION>
+      <CATEGORY_NUMBER>15</CATEGORY_NUMBER>
+      <STYLE_LETTER>B</STYLE_LETTER>
+      <STYLE_GUIDE>BJCP</STYLE_GUIDE>
+      <TYPE>Ale</TYPE>
+      <OG_MIN>1.036</OG_MIN>
+      <OG_MAX>1.050</OG_MAX>
+      <FG_MIN>1.007</FG_MIN>
+      <FG_MAX>1.011</FG_MAX>
+      <IBU_MIN>30</IBU_MIN>
+      <IBU_MAX>45</IBU_MAX>
+      <COLOR_MIN>25</COLOR_MIN>
+      <COLOR_MAX>40</COLOR_MAX>
+    </STYLE>
+    <BREWER>x</BREWER>
+    <BATCH_SIZE>1</BATCH_SIZE>
+    <BOIL_SIZE>1</BOIL_SIZE>
+    <BOIL_TIME>1</BOIL_TIME>
+    <EFFICIENCY>1</EFFICIENCY>
+    <HOPS />
+    <FERMENTABLES />
+    <MISCS />
+    <YEASTS />
+    <WATERS />
+    <MASH>
+      <NAME>x</NAME>
+      <VERSION>1</VERSION>
+      <GRAIN_TEMP>20</GRAIN_TEMP>
+      <MASH_STEPS>
+        <MASH_STEP>
+          <NAME>x</NAME>
+          <VERSION>1</VERSION>
+          <TYPE>Infusion</TYPE>
+          <STEP_TEMP>20</STEP_TEMP>
+          <STEP_TIME>1</STEP_TIME>
+        </MASH_STEP>
+      </MASH_STEPS>
+    </MASH>
+  </RECIPE>
+</RECIPES>
+"""
+    recipe = Recipe()
+    recipe.name = "Style Fields"
+    recipe.version = 1
+    recipe.type = "All Grain"
+    recipe.brewer = "Tester"
+    recipe.batch_size = 20.0
+    recipe.boil_size = 25.0
+    recipe.boil_time = 60.0
+    recipe.efficiency = 75.0
+    recipe.style = Parser().parse_from_string(style_xml)[0].style
+
+    xml = recipe.to_xml_string()
+    roundtripped = Parser().parse_from_string(xml)[0]
+
+    assert roundtripped.style.version == 1
+    assert roundtripped.style.category_number == "15"
+    assert roundtripped.style.style_letter == "B"
+    assert roundtripped.style.style_guide == "BJCP"
+    assert roundtripped.style.type == "Ale"

--- a/tests/test_serializer.py
+++ b/tests/test_serializer.py
@@ -1,7 +1,7 @@
 import os
 from xml.etree import ElementTree
 
-from pybeerxml import Parser, serialize, write
+from pybeerxml import Parser, Serializer
 from pybeerxml.fermentable import Fermentable
 from pybeerxml.hop import Hop
 from pybeerxml.misc import Misc
@@ -269,8 +269,9 @@ def test_roundtrip_coffee_stout_recipe():
 def test_serialize_multiple_recipes_in_one_document():
     parser = Parser()
     recipes = [parser.parse(RECIPE_PATH_1)[0], parser.parse(RECIPE_PATH_2)[0]]
+    serializer = Serializer()
 
-    xml = serialize(recipes)
+    xml = serializer.serialize(recipes)
     tree = ElementTree.fromstring(xml)
     roundtripped = parser.parse_from_string(xml)
 
@@ -390,16 +391,28 @@ def test_empty_optional_sections_are_omitted():
 
 def test_recipe_element_and_write_helpers(tmp_path):
     recipe = Parser().parse(RECIPE_PATH_1)[0]
+    serializer = Serializer()
     single_path = tmp_path / "single.xml"
     multiple_path = tmp_path / "multiple.xml"
 
     recipe_element = recipe.to_xml_element()
     recipe.write_xml(str(single_path))
-    write([recipe, Parser().parse(RECIPE_PATH_2)[0]], str(multiple_path))
+    serializer.write([recipe, Parser().parse(RECIPE_PATH_2)[0]], str(multiple_path))
 
     assert recipe_element.tag == "RECIPE"
     assert Parser().parse(str(single_path))[0].name == recipe.name
     assert len(Parser().parse(str(multiple_path))) == 2
+
+def test_serializer_class_writes_file(tmp_path):
+    serializer = Serializer()
+    recipes = [Parser().parse(RECIPE_PATH_1)[0]]
+    output_path = tmp_path / "serializer.xml"
+
+    xml = serializer.serialize(recipes)
+    serializer.write(recipes, str(output_path))
+
+    assert "<RECIPES>" in xml
+    assert Parser().parse(str(output_path))[0].name == recipes[0].name
 
 
 def test_parser_preserves_integer_version_fields():

--- a/uv.lock
+++ b/uv.lock
@@ -3,6 +3,15 @@ revision = 3
 requires-python = ">=3.10"
 
 [[package]]
+name = "annotated-types"
+version = "0.7.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ee/67/531ea369ba64dcff5ec9c3402f9f51bf748cec26dde048a2f973a4eea7f5/annotated_types-0.7.0.tar.gz", hash = "sha256:aff07c09a53a08bc8cfccb9c85b05f1aa9a2a6f23728d790723543408344ce89", size = 16081, upload-time = "2024-05-20T21:33:25.928Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/78/b6/6307fbef88d9b5ee7421e68d78a9f162e0da4900bc5f5793f6d3d0e34fb8/annotated_types-0.7.0-py3-none-any.whl", hash = "sha256:1f02e8b43a8fbbc3f3e0d4f0f4bfc8131bcb4eebe8849b8e5c773f3a1c582a53", size = 13643, upload-time = "2024-05-20T21:33:24.1Z" },
+]
+
+[[package]]
 name = "click"
 version = "8.3.1"
 source = { registry = "https://pypi.org/simple" }
@@ -313,6 +322,10 @@ wheels = [
 name = "pybeerxml"
 version = "2.2.0"
 source = { editable = "." }
+dependencies = [
+    { name = "pydantic" },
+    { name = "pydantic-xml" },
+]
 
 [package.dev-dependencies]
 dev = [
@@ -324,6 +337,10 @@ dev = [
 ]
 
 [package.metadata]
+requires-dist = [
+    { name = "pydantic", specifier = ">=2.12.0,<3" },
+    { name = "pydantic-xml", specifier = ">=2.18.0,<3" },
+]
 
 [package.metadata.requires-dev]
 dev = [
@@ -332,6 +349,152 @@ dev = [
     { name = "ruff", specifier = ">=0.9" },
     { name = "ty", specifier = ">=0.0.1" },
     { name = "zensical" },
+]
+
+[[package]]
+name = "pydantic"
+version = "2.12.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "annotated-types" },
+    { name = "pydantic-core" },
+    { name = "typing-extensions" },
+    { name = "typing-inspection" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/69/44/36f1a6e523abc58ae5f928898e4aca2e0ea509b5aa6f6f392a5d882be928/pydantic-2.12.5.tar.gz", hash = "sha256:4d351024c75c0f085a9febbb665ce8c0c6ec5d30e903bdb6394b7ede26aebb49", size = 821591, upload-time = "2025-11-26T15:11:46.471Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/5a/87/b70ad306ebb6f9b585f114d0ac2137d792b48be34d732d60e597c2f8465a/pydantic-2.12.5-py3-none-any.whl", hash = "sha256:e561593fccf61e8a20fc46dfc2dfe075b8be7d0188df33f221ad1f0139180f9d", size = 463580, upload-time = "2025-11-26T15:11:44.605Z" },
+]
+
+[[package]]
+name = "pydantic-core"
+version = "2.41.5"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/71/70/23b021c950c2addd24ec408e9ab05d59b035b39d97cdc1130e1bce647bb6/pydantic_core-2.41.5.tar.gz", hash = "sha256:08daa51ea16ad373ffd5e7606252cc32f07bc72b28284b6bc9c6df804816476e", size = 460952, upload-time = "2025-11-04T13:43:49.098Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/c6/90/32c9941e728d564b411d574d8ee0cf09b12ec978cb22b294995bae5549a5/pydantic_core-2.41.5-cp310-cp310-macosx_10_12_x86_64.whl", hash = "sha256:77b63866ca88d804225eaa4af3e664c5faf3568cea95360d21f4725ab6e07146", size = 2107298, upload-time = "2025-11-04T13:39:04.116Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/a8/61c96a77fe28993d9a6fb0f4127e05430a267b235a124545d79fea46dd65/pydantic_core-2.41.5-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:dfa8a0c812ac681395907e71e1274819dec685fec28273a28905df579ef137e2", size = 1901475, upload-time = "2025-11-04T13:39:06.055Z" },
+    { url = "https://files.pythonhosted.org/packages/5d/b6/338abf60225acc18cdc08b4faef592d0310923d19a87fba1faf05af5346e/pydantic_core-2.41.5-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5921a4d3ca3aee735d9fd163808f5e8dd6c6972101e4adbda9a4667908849b97", size = 1918815, upload-time = "2025-11-04T13:39:10.41Z" },
+    { url = "https://files.pythonhosted.org/packages/d1/1c/2ed0433e682983d8e8cba9c8d8ef274d4791ec6a6f24c58935b90e780e0a/pydantic_core-2.41.5-cp310-cp310-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:e25c479382d26a2a41b7ebea1043564a937db462816ea07afa8a44c0866d52f9", size = 2065567, upload-time = "2025-11-04T13:39:12.244Z" },
+    { url = "https://files.pythonhosted.org/packages/b3/24/cf84974ee7d6eae06b9e63289b7b8f6549d416b5c199ca2d7ce13bbcf619/pydantic_core-2.41.5-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:f547144f2966e1e16ae626d8ce72b4cfa0caedc7fa28052001c94fb2fcaa1c52", size = 2230442, upload-time = "2025-11-04T13:39:13.962Z" },
+    { url = "https://files.pythonhosted.org/packages/fd/21/4e287865504b3edc0136c89c9c09431be326168b1eb7841911cbc877a995/pydantic_core-2.41.5-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:6f52298fbd394f9ed112d56f3d11aabd0d5bd27beb3084cc3d8ad069483b8941", size = 2350956, upload-time = "2025-11-04T13:39:15.889Z" },
+    { url = "https://files.pythonhosted.org/packages/a8/76/7727ef2ffa4b62fcab916686a68a0426b9b790139720e1934e8ba797e238/pydantic_core-2.41.5-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:100baa204bb412b74fe285fb0f3a385256dad1d1879f0a5cb1499ed2e83d132a", size = 2068253, upload-time = "2025-11-04T13:39:17.403Z" },
+    { url = "https://files.pythonhosted.org/packages/d5/8c/a4abfc79604bcb4c748e18975c44f94f756f08fb04218d5cb87eb0d3a63e/pydantic_core-2.41.5-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:05a2c8852530ad2812cb7914dc61a1125dc4e06252ee98e5638a12da6cc6fb6c", size = 2177050, upload-time = "2025-11-04T13:39:19.351Z" },
+    { url = "https://files.pythonhosted.org/packages/67/b1/de2e9a9a79b480f9cb0b6e8b6ba4c50b18d4e89852426364c66aa82bb7b3/pydantic_core-2.41.5-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:29452c56df2ed968d18d7e21f4ab0ac55e71dc59524872f6fc57dcf4a3249ed2", size = 2147178, upload-time = "2025-11-04T13:39:21Z" },
+    { url = "https://files.pythonhosted.org/packages/16/c1/dfb33f837a47b20417500efaa0378adc6635b3c79e8369ff7a03c494b4ac/pydantic_core-2.41.5-cp310-cp310-musllinux_1_1_armv7l.whl", hash = "sha256:d5160812ea7a8a2ffbe233d8da666880cad0cbaf5d4de74ae15c313213d62556", size = 2341833, upload-time = "2025-11-04T13:39:22.606Z" },
+    { url = "https://files.pythonhosted.org/packages/47/36/00f398642a0f4b815a9a558c4f1dca1b4020a7d49562807d7bc9ff279a6c/pydantic_core-2.41.5-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:df3959765b553b9440adfd3c795617c352154e497a4eaf3752555cfb5da8fc49", size = 2321156, upload-time = "2025-11-04T13:39:25.843Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/70/cad3acd89fde2010807354d978725ae111ddf6d0ea46d1ea1775b5c1bd0c/pydantic_core-2.41.5-cp310-cp310-win32.whl", hash = "sha256:1f8d33a7f4d5a7889e60dc39856d76d09333d8a6ed0f5f1190635cbec70ec4ba", size = 1989378, upload-time = "2025-11-04T13:39:27.92Z" },
+    { url = "https://files.pythonhosted.org/packages/76/92/d338652464c6c367e5608e4488201702cd1cbb0f33f7b6a85a60fe5f3720/pydantic_core-2.41.5-cp310-cp310-win_amd64.whl", hash = "sha256:62de39db01b8d593e45871af2af9e497295db8d73b085f6bfd0b18c83c70a8f9", size = 2013622, upload-time = "2025-11-04T13:39:29.848Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/72/74a989dd9f2084b3d9530b0915fdda64ac48831c30dbf7c72a41a5232db8/pydantic_core-2.41.5-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:a3a52f6156e73e7ccb0f8cced536adccb7042be67cb45f9562e12b319c119da6", size = 2105873, upload-time = "2025-11-04T13:39:31.373Z" },
+    { url = "https://files.pythonhosted.org/packages/12/44/37e403fd9455708b3b942949e1d7febc02167662bf1a7da5b78ee1ea2842/pydantic_core-2.41.5-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:7f3bf998340c6d4b0c9a2f02d6a400e51f123b59565d74dc60d252ce888c260b", size = 1899826, upload-time = "2025-11-04T13:39:32.897Z" },
+    { url = "https://files.pythonhosted.org/packages/33/7f/1d5cab3ccf44c1935a359d51a8a2a9e1a654b744b5e7f80d41b88d501eec/pydantic_core-2.41.5-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:378bec5c66998815d224c9ca994f1e14c0c21cb95d2f52b6021cc0b2a58f2a5a", size = 1917869, upload-time = "2025-11-04T13:39:34.469Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/6a/30d94a9674a7fe4f4744052ed6c5e083424510be1e93da5bc47569d11810/pydantic_core-2.41.5-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:e7b576130c69225432866fe2f4a469a85a54ade141d96fd396dffcf607b558f8", size = 2063890, upload-time = "2025-11-04T13:39:36.053Z" },
+    { url = "https://files.pythonhosted.org/packages/50/be/76e5d46203fcb2750e542f32e6c371ffa9b8ad17364cf94bb0818dbfb50c/pydantic_core-2.41.5-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:6cb58b9c66f7e4179a2d5e0f849c48eff5c1fca560994d6eb6543abf955a149e", size = 2229740, upload-time = "2025-11-04T13:39:37.753Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/ee/fed784df0144793489f87db310a6bbf8118d7b630ed07aa180d6067e653a/pydantic_core-2.41.5-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:88942d3a3dff3afc8288c21e565e476fc278902ae4d6d134f1eeda118cc830b1", size = 2350021, upload-time = "2025-11-04T13:39:40.94Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/be/8fed28dd0a180dca19e72c233cbf58efa36df055e5b9d90d64fd1740b828/pydantic_core-2.41.5-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f31d95a179f8d64d90f6831d71fa93290893a33148d890ba15de25642c5d075b", size = 2066378, upload-time = "2025-11-04T13:39:42.523Z" },
+    { url = "https://files.pythonhosted.org/packages/b0/3b/698cf8ae1d536a010e05121b4958b1257f0b5522085e335360e53a6b1c8b/pydantic_core-2.41.5-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:c1df3d34aced70add6f867a8cf413e299177e0c22660cc767218373d0779487b", size = 2175761, upload-time = "2025-11-04T13:39:44.553Z" },
+    { url = "https://files.pythonhosted.org/packages/b8/ba/15d537423939553116dea94ce02f9c31be0fa9d0b806d427e0308ec17145/pydantic_core-2.41.5-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:4009935984bd36bd2c774e13f9a09563ce8de4abaa7226f5108262fa3e637284", size = 2146303, upload-time = "2025-11-04T13:39:46.238Z" },
+    { url = "https://files.pythonhosted.org/packages/58/7f/0de669bf37d206723795f9c90c82966726a2ab06c336deba4735b55af431/pydantic_core-2.41.5-cp311-cp311-musllinux_1_1_armv7l.whl", hash = "sha256:34a64bc3441dc1213096a20fe27e8e128bd3ff89921706e83c0b1ac971276594", size = 2340355, upload-time = "2025-11-04T13:39:48.002Z" },
+    { url = "https://files.pythonhosted.org/packages/e5/de/e7482c435b83d7e3c3ee5ee4451f6e8973cff0eb6007d2872ce6383f6398/pydantic_core-2.41.5-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:c9e19dd6e28fdcaa5a1de679aec4141f691023916427ef9bae8584f9c2fb3b0e", size = 2319875, upload-time = "2025-11-04T13:39:49.705Z" },
+    { url = "https://files.pythonhosted.org/packages/fe/e6/8c9e81bb6dd7560e33b9053351c29f30c8194b72f2d6932888581f503482/pydantic_core-2.41.5-cp311-cp311-win32.whl", hash = "sha256:2c010c6ded393148374c0f6f0bf89d206bf3217f201faa0635dcd56bd1520f6b", size = 1987549, upload-time = "2025-11-04T13:39:51.842Z" },
+    { url = "https://files.pythonhosted.org/packages/11/66/f14d1d978ea94d1bc21fc98fcf570f9542fe55bfcc40269d4e1a21c19bf7/pydantic_core-2.41.5-cp311-cp311-win_amd64.whl", hash = "sha256:76ee27c6e9c7f16f47db7a94157112a2f3a00e958bc626e2f4ee8bec5c328fbe", size = 2011305, upload-time = "2025-11-04T13:39:53.485Z" },
+    { url = "https://files.pythonhosted.org/packages/56/d8/0e271434e8efd03186c5386671328154ee349ff0354d83c74f5caaf096ed/pydantic_core-2.41.5-cp311-cp311-win_arm64.whl", hash = "sha256:4bc36bbc0b7584de96561184ad7f012478987882ebf9f9c389b23f432ea3d90f", size = 1972902, upload-time = "2025-11-04T13:39:56.488Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/5d/5f6c63eebb5afee93bcaae4ce9a898f3373ca23df3ccaef086d0233a35a7/pydantic_core-2.41.5-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:f41a7489d32336dbf2199c8c0a215390a751c5b014c2c1c5366e817202e9cdf7", size = 2110990, upload-time = "2025-11-04T13:39:58.079Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/32/9c2e8ccb57c01111e0fd091f236c7b371c1bccea0fa85247ac55b1e2b6b6/pydantic_core-2.41.5-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:070259a8818988b9a84a449a2a7337c7f430a22acc0859c6b110aa7212a6d9c0", size = 1896003, upload-time = "2025-11-04T13:39:59.956Z" },
+    { url = "https://files.pythonhosted.org/packages/68/b8/a01b53cb0e59139fbc9e4fda3e9724ede8de279097179be4ff31f1abb65a/pydantic_core-2.41.5-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e96cea19e34778f8d59fe40775a7a574d95816eb150850a85a7a4c8f4b94ac69", size = 1919200, upload-time = "2025-11-04T13:40:02.241Z" },
+    { url = "https://files.pythonhosted.org/packages/38/de/8c36b5198a29bdaade07b5985e80a233a5ac27137846f3bc2d3b40a47360/pydantic_core-2.41.5-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:ed2e99c456e3fadd05c991f8f437ef902e00eedf34320ba2b0842bd1c3ca3a75", size = 2052578, upload-time = "2025-11-04T13:40:04.401Z" },
+    { url = "https://files.pythonhosted.org/packages/00/b5/0e8e4b5b081eac6cb3dbb7e60a65907549a1ce035a724368c330112adfdd/pydantic_core-2.41.5-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:65840751b72fbfd82c3c640cff9284545342a4f1eb1586ad0636955b261b0b05", size = 2208504, upload-time = "2025-11-04T13:40:06.072Z" },
+    { url = "https://files.pythonhosted.org/packages/77/56/87a61aad59c7c5b9dc8caad5a41a5545cba3810c3e828708b3d7404f6cef/pydantic_core-2.41.5-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:e536c98a7626a98feb2d3eaf75944ef6f3dbee447e1f841eae16f2f0a72d8ddc", size = 2335816, upload-time = "2025-11-04T13:40:07.835Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/76/941cc9f73529988688a665a5c0ecff1112b3d95ab48f81db5f7606f522d3/pydantic_core-2.41.5-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:eceb81a8d74f9267ef4081e246ffd6d129da5d87e37a77c9bde550cb04870c1c", size = 2075366, upload-time = "2025-11-04T13:40:09.804Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/43/ebef01f69baa07a482844faaa0a591bad1ef129253ffd0cdaa9d8a7f72d3/pydantic_core-2.41.5-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:d38548150c39b74aeeb0ce8ee1d8e82696f4a4e16ddc6de7b1d8823f7de4b9b5", size = 2171698, upload-time = "2025-11-04T13:40:12.004Z" },
+    { url = "https://files.pythonhosted.org/packages/b1/87/41f3202e4193e3bacfc2c065fab7706ebe81af46a83d3e27605029c1f5a6/pydantic_core-2.41.5-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:c23e27686783f60290e36827f9c626e63154b82b116d7fe9adba1fda36da706c", size = 2132603, upload-time = "2025-11-04T13:40:13.868Z" },
+    { url = "https://files.pythonhosted.org/packages/49/7d/4c00df99cb12070b6bccdef4a195255e6020a550d572768d92cc54dba91a/pydantic_core-2.41.5-cp312-cp312-musllinux_1_1_armv7l.whl", hash = "sha256:482c982f814460eabe1d3bb0adfdc583387bd4691ef00b90575ca0d2b6fe2294", size = 2329591, upload-time = "2025-11-04T13:40:15.672Z" },
+    { url = "https://files.pythonhosted.org/packages/cc/6a/ebf4b1d65d458f3cda6a7335d141305dfa19bdc61140a884d165a8a1bbc7/pydantic_core-2.41.5-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:bfea2a5f0b4d8d43adf9d7b8bf019fb46fdd10a2e5cde477fbcb9d1fa08c68e1", size = 2319068, upload-time = "2025-11-04T13:40:17.532Z" },
+    { url = "https://files.pythonhosted.org/packages/49/3b/774f2b5cd4192d5ab75870ce4381fd89cf218af999515baf07e7206753f0/pydantic_core-2.41.5-cp312-cp312-win32.whl", hash = "sha256:b74557b16e390ec12dca509bce9264c3bbd128f8a2c376eaa68003d7f327276d", size = 1985908, upload-time = "2025-11-04T13:40:19.309Z" },
+    { url = "https://files.pythonhosted.org/packages/86/45/00173a033c801cacf67c190fef088789394feaf88a98a7035b0e40d53dc9/pydantic_core-2.41.5-cp312-cp312-win_amd64.whl", hash = "sha256:1962293292865bca8e54702b08a4f26da73adc83dd1fcf26fbc875b35d81c815", size = 2020145, upload-time = "2025-11-04T13:40:21.548Z" },
+    { url = "https://files.pythonhosted.org/packages/f9/22/91fbc821fa6d261b376a3f73809f907cec5ca6025642c463d3488aad22fb/pydantic_core-2.41.5-cp312-cp312-win_arm64.whl", hash = "sha256:1746d4a3d9a794cacae06a5eaaccb4b8643a131d45fbc9af23e353dc0a5ba5c3", size = 1976179, upload-time = "2025-11-04T13:40:23.393Z" },
+    { url = "https://files.pythonhosted.org/packages/87/06/8806241ff1f70d9939f9af039c6c35f2360cf16e93c2ca76f184e76b1564/pydantic_core-2.41.5-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:941103c9be18ac8daf7b7adca8228f8ed6bb7a1849020f643b3a14d15b1924d9", size = 2120403, upload-time = "2025-11-04T13:40:25.248Z" },
+    { url = "https://files.pythonhosted.org/packages/94/02/abfa0e0bda67faa65fef1c84971c7e45928e108fe24333c81f3bfe35d5f5/pydantic_core-2.41.5-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:112e305c3314f40c93998e567879e887a3160bb8689ef3d2c04b6cc62c33ac34", size = 1896206, upload-time = "2025-11-04T13:40:27.099Z" },
+    { url = "https://files.pythonhosted.org/packages/15/df/a4c740c0943e93e6500f9eb23f4ca7ec9bf71b19e608ae5b579678c8d02f/pydantic_core-2.41.5-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0cbaad15cb0c90aa221d43c00e77bb33c93e8d36e0bf74760cd00e732d10a6a0", size = 1919307, upload-time = "2025-11-04T13:40:29.806Z" },
+    { url = "https://files.pythonhosted.org/packages/9a/e3/6324802931ae1d123528988e0e86587c2072ac2e5394b4bc2bc34b61ff6e/pydantic_core-2.41.5-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:03ca43e12fab6023fc79d28ca6b39b05f794ad08ec2feccc59a339b02f2b3d33", size = 2063258, upload-time = "2025-11-04T13:40:33.544Z" },
+    { url = "https://files.pythonhosted.org/packages/c9/d4/2230d7151d4957dd79c3044ea26346c148c98fbf0ee6ebd41056f2d62ab5/pydantic_core-2.41.5-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:dc799088c08fa04e43144b164feb0c13f9a0bc40503f8df3e9fde58a3c0c101e", size = 2214917, upload-time = "2025-11-04T13:40:35.479Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/9f/eaac5df17a3672fef0081b6c1bb0b82b33ee89aa5cec0d7b05f52fd4a1fa/pydantic_core-2.41.5-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:97aeba56665b4c3235a0e52b2c2f5ae9cd071b8a8310ad27bddb3f7fb30e9aa2", size = 2332186, upload-time = "2025-11-04T13:40:37.436Z" },
+    { url = "https://files.pythonhosted.org/packages/cf/4e/35a80cae583a37cf15604b44240e45c05e04e86f9cfd766623149297e971/pydantic_core-2.41.5-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:406bf18d345822d6c21366031003612b9c77b3e29ffdb0f612367352aab7d586", size = 2073164, upload-time = "2025-11-04T13:40:40.289Z" },
+    { url = "https://files.pythonhosted.org/packages/bf/e3/f6e262673c6140dd3305d144d032f7bd5f7497d3871c1428521f19f9efa2/pydantic_core-2.41.5-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:b93590ae81f7010dbe380cdeab6f515902ebcbefe0b9327cc4804d74e93ae69d", size = 2179146, upload-time = "2025-11-04T13:40:42.809Z" },
+    { url = "https://files.pythonhosted.org/packages/75/c7/20bd7fc05f0c6ea2056a4565c6f36f8968c0924f19b7d97bbfea55780e73/pydantic_core-2.41.5-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:01a3d0ab748ee531f4ea6c3e48ad9dac84ddba4b0d82291f87248f2f9de8d740", size = 2137788, upload-time = "2025-11-04T13:40:44.752Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/8d/34318ef985c45196e004bc46c6eab2eda437e744c124ef0dbe1ff2c9d06b/pydantic_core-2.41.5-cp313-cp313-musllinux_1_1_armv7l.whl", hash = "sha256:6561e94ba9dacc9c61bce40e2d6bdc3bfaa0259d3ff36ace3b1e6901936d2e3e", size = 2340133, upload-time = "2025-11-04T13:40:46.66Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/59/013626bf8c78a5a5d9350d12e7697d3d4de951a75565496abd40ccd46bee/pydantic_core-2.41.5-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:915c3d10f81bec3a74fbd4faebe8391013ba61e5a1a8d48c4455b923bdda7858", size = 2324852, upload-time = "2025-11-04T13:40:48.575Z" },
+    { url = "https://files.pythonhosted.org/packages/1a/d9/c248c103856f807ef70c18a4f986693a46a8ffe1602e5d361485da502d20/pydantic_core-2.41.5-cp313-cp313-win32.whl", hash = "sha256:650ae77860b45cfa6e2cdafc42618ceafab3a2d9a3811fcfbd3bbf8ac3c40d36", size = 1994679, upload-time = "2025-11-04T13:40:50.619Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/8b/341991b158ddab181cff136acd2552c9f35bd30380422a639c0671e99a91/pydantic_core-2.41.5-cp313-cp313-win_amd64.whl", hash = "sha256:79ec52ec461e99e13791ec6508c722742ad745571f234ea6255bed38c6480f11", size = 2019766, upload-time = "2025-11-04T13:40:52.631Z" },
+    { url = "https://files.pythonhosted.org/packages/73/7d/f2f9db34af103bea3e09735bb40b021788a5e834c81eedb541991badf8f5/pydantic_core-2.41.5-cp313-cp313-win_arm64.whl", hash = "sha256:3f84d5c1b4ab906093bdc1ff10484838aca54ef08de4afa9de0f5f14d69639cd", size = 1981005, upload-time = "2025-11-04T13:40:54.734Z" },
+    { url = "https://files.pythonhosted.org/packages/ea/28/46b7c5c9635ae96ea0fbb779e271a38129df2550f763937659ee6c5dbc65/pydantic_core-2.41.5-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:3f37a19d7ebcdd20b96485056ba9e8b304e27d9904d233d7b1015db320e51f0a", size = 2119622, upload-time = "2025-11-04T13:40:56.68Z" },
+    { url = "https://files.pythonhosted.org/packages/74/1a/145646e5687e8d9a1e8d09acb278c8535ebe9e972e1f162ed338a622f193/pydantic_core-2.41.5-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:1d1d9764366c73f996edd17abb6d9d7649a7eb690006ab6adbda117717099b14", size = 1891725, upload-time = "2025-11-04T13:40:58.807Z" },
+    { url = "https://files.pythonhosted.org/packages/23/04/e89c29e267b8060b40dca97bfc64a19b2a3cf99018167ea1677d96368273/pydantic_core-2.41.5-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:25e1c2af0fce638d5f1988b686f3b3ea8cd7de5f244ca147c777769e798a9cd1", size = 1915040, upload-time = "2025-11-04T13:41:00.853Z" },
+    { url = "https://files.pythonhosted.org/packages/84/a3/15a82ac7bd97992a82257f777b3583d3e84bdb06ba6858f745daa2ec8a85/pydantic_core-2.41.5-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:506d766a8727beef16b7adaeb8ee6217c64fc813646b424d0804d67c16eddb66", size = 2063691, upload-time = "2025-11-04T13:41:03.504Z" },
+    { url = "https://files.pythonhosted.org/packages/74/9b/0046701313c6ef08c0c1cf0e028c67c770a4e1275ca73131563c5f2a310a/pydantic_core-2.41.5-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:4819fa52133c9aa3c387b3328f25c1facc356491e6135b459f1de698ff64d869", size = 2213897, upload-time = "2025-11-04T13:41:05.804Z" },
+    { url = "https://files.pythonhosted.org/packages/8a/cd/6bac76ecd1b27e75a95ca3a9a559c643b3afcd2dd62086d4b7a32a18b169/pydantic_core-2.41.5-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:2b761d210c9ea91feda40d25b4efe82a1707da2ef62901466a42492c028553a2", size = 2333302, upload-time = "2025-11-04T13:41:07.809Z" },
+    { url = "https://files.pythonhosted.org/packages/4c/d2/ef2074dc020dd6e109611a8be4449b98cd25e1b9b8a303c2f0fca2f2bcf7/pydantic_core-2.41.5-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:22f0fb8c1c583a3b6f24df2470833b40207e907b90c928cc8d3594b76f874375", size = 2064877, upload-time = "2025-11-04T13:41:09.827Z" },
+    { url = "https://files.pythonhosted.org/packages/18/66/e9db17a9a763d72f03de903883c057b2592c09509ccfe468187f2a2eef29/pydantic_core-2.41.5-cp314-cp314-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:2782c870e99878c634505236d81e5443092fba820f0373997ff75f90f68cd553", size = 2180680, upload-time = "2025-11-04T13:41:12.379Z" },
+    { url = "https://files.pythonhosted.org/packages/d3/9e/3ce66cebb929f3ced22be85d4c2399b8e85b622db77dad36b73c5387f8f8/pydantic_core-2.41.5-cp314-cp314-musllinux_1_1_aarch64.whl", hash = "sha256:0177272f88ab8312479336e1d777f6b124537d47f2123f89cb37e0accea97f90", size = 2138960, upload-time = "2025-11-04T13:41:14.627Z" },
+    { url = "https://files.pythonhosted.org/packages/a6/62/205a998f4327d2079326b01abee48e502ea739d174f0a89295c481a2272e/pydantic_core-2.41.5-cp314-cp314-musllinux_1_1_armv7l.whl", hash = "sha256:63510af5e38f8955b8ee5687740d6ebf7c2a0886d15a6d65c32814613681bc07", size = 2339102, upload-time = "2025-11-04T13:41:16.868Z" },
+    { url = "https://files.pythonhosted.org/packages/3c/0d/f05e79471e889d74d3d88f5bd20d0ed189ad94c2423d81ff8d0000aab4ff/pydantic_core-2.41.5-cp314-cp314-musllinux_1_1_x86_64.whl", hash = "sha256:e56ba91f47764cc14f1daacd723e3e82d1a89d783f0f5afe9c364b8bb491ccdb", size = 2326039, upload-time = "2025-11-04T13:41:18.934Z" },
+    { url = "https://files.pythonhosted.org/packages/ec/e1/e08a6208bb100da7e0c4b288eed624a703f4d129bde2da475721a80cab32/pydantic_core-2.41.5-cp314-cp314-win32.whl", hash = "sha256:aec5cf2fd867b4ff45b9959f8b20ea3993fc93e63c7363fe6851424c8a7e7c23", size = 1995126, upload-time = "2025-11-04T13:41:21.418Z" },
+    { url = "https://files.pythonhosted.org/packages/48/5d/56ba7b24e9557f99c9237e29f5c09913c81eeb2f3217e40e922353668092/pydantic_core-2.41.5-cp314-cp314-win_amd64.whl", hash = "sha256:8e7c86f27c585ef37c35e56a96363ab8de4e549a95512445b85c96d3e2f7c1bf", size = 2015489, upload-time = "2025-11-04T13:41:24.076Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/bb/f7a190991ec9e3e0ba22e4993d8755bbc4a32925c0b5b42775c03e8148f9/pydantic_core-2.41.5-cp314-cp314-win_arm64.whl", hash = "sha256:e672ba74fbc2dc8eea59fb6d4aed6845e6905fc2a8afe93175d94a83ba2a01a0", size = 1977288, upload-time = "2025-11-04T13:41:26.33Z" },
+    { url = "https://files.pythonhosted.org/packages/92/ed/77542d0c51538e32e15afe7899d79efce4b81eee631d99850edc2f5e9349/pydantic_core-2.41.5-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:8566def80554c3faa0e65ac30ab0932b9e3a5cd7f8323764303d468e5c37595a", size = 2120255, upload-time = "2025-11-04T13:41:28.569Z" },
+    { url = "https://files.pythonhosted.org/packages/bb/3d/6913dde84d5be21e284439676168b28d8bbba5600d838b9dca99de0fad71/pydantic_core-2.41.5-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:b80aa5095cd3109962a298ce14110ae16b8c1aece8b72f9dafe81cf597ad80b3", size = 1863760, upload-time = "2025-11-04T13:41:31.055Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/f0/e5e6b99d4191da102f2b0eb9687aaa7f5bea5d9964071a84effc3e40f997/pydantic_core-2.41.5-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:3006c3dd9ba34b0c094c544c6006cc79e87d8612999f1a5d43b769b89181f23c", size = 1878092, upload-time = "2025-11-04T13:41:33.21Z" },
+    { url = "https://files.pythonhosted.org/packages/71/48/36fb760642d568925953bcc8116455513d6e34c4beaa37544118c36aba6d/pydantic_core-2.41.5-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:72f6c8b11857a856bcfa48c86f5368439f74453563f951e473514579d44aa612", size = 2053385, upload-time = "2025-11-04T13:41:35.508Z" },
+    { url = "https://files.pythonhosted.org/packages/20/25/92dc684dd8eb75a234bc1c764b4210cf2646479d54b47bf46061657292a8/pydantic_core-2.41.5-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:5cb1b2f9742240e4bb26b652a5aeb840aa4b417c7748b6f8387927bc6e45e40d", size = 2218832, upload-time = "2025-11-04T13:41:37.732Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/09/f53e0b05023d3e30357d82eb35835d0f6340ca344720a4599cd663dca599/pydantic_core-2.41.5-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:bd3d54f38609ff308209bd43acea66061494157703364ae40c951f83ba99a1a9", size = 2327585, upload-time = "2025-11-04T13:41:40Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/4e/2ae1aa85d6af35a39b236b1b1641de73f5a6ac4d5a7509f77b814885760c/pydantic_core-2.41.5-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:2ff4321e56e879ee8d2a879501c8e469414d948f4aba74a2d4593184eb326660", size = 2041078, upload-time = "2025-11-04T13:41:42.323Z" },
+    { url = "https://files.pythonhosted.org/packages/cd/13/2e215f17f0ef326fc72afe94776edb77525142c693767fc347ed6288728d/pydantic_core-2.41.5-cp314-cp314t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:d0d2568a8c11bf8225044aa94409e21da0cb09dcdafe9ecd10250b2baad531a9", size = 2173914, upload-time = "2025-11-04T13:41:45.221Z" },
+    { url = "https://files.pythonhosted.org/packages/02/7a/f999a6dcbcd0e5660bc348a3991c8915ce6599f4f2c6ac22f01d7a10816c/pydantic_core-2.41.5-cp314-cp314t-musllinux_1_1_aarch64.whl", hash = "sha256:a39455728aabd58ceabb03c90e12f71fd30fa69615760a075b9fec596456ccc3", size = 2129560, upload-time = "2025-11-04T13:41:47.474Z" },
+    { url = "https://files.pythonhosted.org/packages/3a/b1/6c990ac65e3b4c079a4fb9f5b05f5b013afa0f4ed6780a3dd236d2cbdc64/pydantic_core-2.41.5-cp314-cp314t-musllinux_1_1_armv7l.whl", hash = "sha256:239edca560d05757817c13dc17c50766136d21f7cd0fac50295499ae24f90fdf", size = 2329244, upload-time = "2025-11-04T13:41:49.992Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/02/3c562f3a51afd4d88fff8dffb1771b30cfdfd79befd9883ee094f5b6c0d8/pydantic_core-2.41.5-cp314-cp314t-musllinux_1_1_x86_64.whl", hash = "sha256:2a5e06546e19f24c6a96a129142a75cee553cc018ffee48a460059b1185f4470", size = 2331955, upload-time = "2025-11-04T13:41:54.079Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/96/5fb7d8c3c17bc8c62fdb031c47d77a1af698f1d7a406b0f79aaa1338f9ad/pydantic_core-2.41.5-cp314-cp314t-win32.whl", hash = "sha256:b4ececa40ac28afa90871c2cc2b9ffd2ff0bf749380fbdf57d165fd23da353aa", size = 1988906, upload-time = "2025-11-04T13:41:56.606Z" },
+    { url = "https://files.pythonhosted.org/packages/22/ed/182129d83032702912c2e2d8bbe33c036f342cc735737064668585dac28f/pydantic_core-2.41.5-cp314-cp314t-win_amd64.whl", hash = "sha256:80aa89cad80b32a912a65332f64a4450ed00966111b6615ca6816153d3585a8c", size = 1981607, upload-time = "2025-11-04T13:41:58.889Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/ed/068e41660b832bb0b1aa5b58011dea2a3fe0ba7861ff38c4d4904c1c1a99/pydantic_core-2.41.5-cp314-cp314t-win_arm64.whl", hash = "sha256:35b44f37a3199f771c3eaa53051bc8a70cd7b54f333531c59e29fd4db5d15008", size = 1974769, upload-time = "2025-11-04T13:42:01.186Z" },
+    { url = "https://files.pythonhosted.org/packages/11/72/90fda5ee3b97e51c494938a4a44c3a35a9c96c19bba12372fb9c634d6f57/pydantic_core-2.41.5-graalpy311-graalpy242_311_native-macosx_10_12_x86_64.whl", hash = "sha256:b96d5f26b05d03cc60f11a7761a5ded1741da411e7fe0909e27a5e6a0cb7b034", size = 2115441, upload-time = "2025-11-04T13:42:39.557Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/53/8942f884fa33f50794f119012dc6a1a02ac43a56407adaac20463df8e98f/pydantic_core-2.41.5-graalpy311-graalpy242_311_native-macosx_11_0_arm64.whl", hash = "sha256:634e8609e89ceecea15e2d61bc9ac3718caaaa71963717bf3c8f38bfde64242c", size = 1930291, upload-time = "2025-11-04T13:42:42.169Z" },
+    { url = "https://files.pythonhosted.org/packages/79/c8/ecb9ed9cd942bce09fc888ee960b52654fbdbede4ba6c2d6e0d3b1d8b49c/pydantic_core-2.41.5-graalpy311-graalpy242_311_native-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:93e8740d7503eb008aa2df04d3b9735f845d43ae845e6dcd2be0b55a2da43cd2", size = 1948632, upload-time = "2025-11-04T13:42:44.564Z" },
+    { url = "https://files.pythonhosted.org/packages/2e/1b/687711069de7efa6af934e74f601e2a4307365e8fdc404703afc453eab26/pydantic_core-2.41.5-graalpy311-graalpy242_311_native-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f15489ba13d61f670dcc96772e733aad1a6f9c429cc27574c6cdaed82d0146ad", size = 2138905, upload-time = "2025-11-04T13:42:47.156Z" },
+    { url = "https://files.pythonhosted.org/packages/09/32/59b0c7e63e277fa7911c2fc70ccfb45ce4b98991e7ef37110663437005af/pydantic_core-2.41.5-graalpy312-graalpy250_312_native-macosx_10_12_x86_64.whl", hash = "sha256:7da7087d756b19037bc2c06edc6c170eeef3c3bafcb8f532ff17d64dc427adfd", size = 2110495, upload-time = "2025-11-04T13:42:49.689Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/81/05e400037eaf55ad400bcd318c05bb345b57e708887f07ddb2d20e3f0e98/pydantic_core-2.41.5-graalpy312-graalpy250_312_native-macosx_11_0_arm64.whl", hash = "sha256:aabf5777b5c8ca26f7824cb4a120a740c9588ed58df9b2d196ce92fba42ff8dc", size = 1915388, upload-time = "2025-11-04T13:42:52.215Z" },
+    { url = "https://files.pythonhosted.org/packages/6e/0d/e3549b2399f71d56476b77dbf3cf8937cec5cd70536bdc0e374a421d0599/pydantic_core-2.41.5-graalpy312-graalpy250_312_native-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c007fe8a43d43b3969e8469004e9845944f1a80e6acd47c150856bb87f230c56", size = 1942879, upload-time = "2025-11-04T13:42:56.483Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/07/34573da085946b6a313d7c42f82f16e8920bfd730665de2d11c0c37a74b5/pydantic_core-2.41.5-graalpy312-graalpy250_312_native-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:76d0819de158cd855d1cbb8fcafdf6f5cf1eb8e470abe056d5d161106e38062b", size = 2139017, upload-time = "2025-11-04T13:42:59.471Z" },
+    { url = "https://files.pythonhosted.org/packages/e6/b0/1a2aa41e3b5a4ba11420aba2d091b2d17959c8d1519ece3627c371951e73/pydantic_core-2.41.5-pp310-pypy310_pp73-macosx_10_12_x86_64.whl", hash = "sha256:b5819cd790dbf0c5eb9f82c73c16b39a65dd6dd4d1439dcdea7816ec9adddab8", size = 2103351, upload-time = "2025-11-04T13:43:02.058Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/ee/31b1f0020baaf6d091c87900ae05c6aeae101fa4e188e1613c80e4f1ea31/pydantic_core-2.41.5-pp310-pypy310_pp73-macosx_11_0_arm64.whl", hash = "sha256:5a4e67afbc95fa5c34cf27d9089bca7fcab4e51e57278d710320a70b956d1b9a", size = 1925363, upload-time = "2025-11-04T13:43:05.159Z" },
+    { url = "https://files.pythonhosted.org/packages/e1/89/ab8e86208467e467a80deaca4e434adac37b10a9d134cd2f99b28a01e483/pydantic_core-2.41.5-pp310-pypy310_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:ece5c59f0ce7d001e017643d8d24da587ea1f74f6993467d85ae8a5ef9d4f42b", size = 2135615, upload-time = "2025-11-04T13:43:08.116Z" },
+    { url = "https://files.pythonhosted.org/packages/99/0a/99a53d06dd0348b2008f2f30884b34719c323f16c3be4e6cc1203b74a91d/pydantic_core-2.41.5-pp310-pypy310_pp73-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:16f80f7abe3351f8ea6858914ddc8c77e02578544a0ebc15b4c2e1a0e813b0b2", size = 2175369, upload-time = "2025-11-04T13:43:12.49Z" },
+    { url = "https://files.pythonhosted.org/packages/6d/94/30ca3b73c6d485b9bb0bc66e611cff4a7138ff9736b7e66bcf0852151636/pydantic_core-2.41.5-pp310-pypy310_pp73-musllinux_1_1_aarch64.whl", hash = "sha256:33cb885e759a705b426baada1fe68cbb0a2e68e34c5d0d0289a364cf01709093", size = 2144218, upload-time = "2025-11-04T13:43:15.431Z" },
+    { url = "https://files.pythonhosted.org/packages/87/57/31b4f8e12680b739a91f472b5671294236b82586889ef764b5fbc6669238/pydantic_core-2.41.5-pp310-pypy310_pp73-musllinux_1_1_armv7l.whl", hash = "sha256:c8d8b4eb992936023be7dee581270af5c6e0697a8559895f527f5b7105ecd36a", size = 2329951, upload-time = "2025-11-04T13:43:18.062Z" },
+    { url = "https://files.pythonhosted.org/packages/7d/73/3c2c8edef77b8f7310e6fb012dbc4b8551386ed575b9eb6fb2506e28a7eb/pydantic_core-2.41.5-pp310-pypy310_pp73-musllinux_1_1_x86_64.whl", hash = "sha256:242a206cd0318f95cd21bdacff3fcc3aab23e79bba5cac3db5a841c9ef9c6963", size = 2318428, upload-time = "2025-11-04T13:43:20.679Z" },
+    { url = "https://files.pythonhosted.org/packages/2f/02/8559b1f26ee0d502c74f9cca5c0d2fd97e967e083e006bbbb4e97f3a043a/pydantic_core-2.41.5-pp310-pypy310_pp73-win_amd64.whl", hash = "sha256:d3a978c4f57a597908b7e697229d996d77a6d3c94901e9edee593adada95ce1a", size = 2147009, upload-time = "2025-11-04T13:43:23.286Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/9b/1b3f0e9f9305839d7e84912f9e8bfbd191ed1b1ef48083609f0dabde978c/pydantic_core-2.41.5-pp311-pypy311_pp73-macosx_10_12_x86_64.whl", hash = "sha256:b2379fa7ed44ddecb5bfe4e48577d752db9fc10be00a6b7446e9663ba143de26", size = 2101980, upload-time = "2025-11-04T13:43:25.97Z" },
+    { url = "https://files.pythonhosted.org/packages/a4/ed/d71fefcb4263df0da6a85b5d8a7508360f2f2e9b3bf5814be9c8bccdccc1/pydantic_core-2.41.5-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:266fb4cbf5e3cbd0b53669a6d1b039c45e3ce651fd5442eff4d07c2cc8d66808", size = 1923865, upload-time = "2025-11-04T13:43:28.763Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/3a/626b38db460d675f873e4444b4bb030453bbe7b4ba55df821d026a0493c4/pydantic_core-2.41.5-pp311-pypy311_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:58133647260ea01e4d0500089a8c4f07bd7aa6ce109682b1426394988d8aaacc", size = 2134256, upload-time = "2025-11-04T13:43:31.71Z" },
+    { url = "https://files.pythonhosted.org/packages/83/d9/8412d7f06f616bbc053d30cb4e5f76786af3221462ad5eee1f202021eb4e/pydantic_core-2.41.5-pp311-pypy311_pp73-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:287dad91cfb551c363dc62899a80e9e14da1f0e2b6ebde82c806612ca2a13ef1", size = 2174762, upload-time = "2025-11-04T13:43:34.744Z" },
+    { url = "https://files.pythonhosted.org/packages/55/4c/162d906b8e3ba3a99354e20faa1b49a85206c47de97a639510a0e673f5da/pydantic_core-2.41.5-pp311-pypy311_pp73-musllinux_1_1_aarch64.whl", hash = "sha256:03b77d184b9eb40240ae9fd676ca364ce1085f203e1b1256f8ab9984dca80a84", size = 2143141, upload-time = "2025-11-04T13:43:37.701Z" },
+    { url = "https://files.pythonhosted.org/packages/1f/f2/f11dd73284122713f5f89fc940f370d035fa8e1e078d446b3313955157fe/pydantic_core-2.41.5-pp311-pypy311_pp73-musllinux_1_1_armv7l.whl", hash = "sha256:a668ce24de96165bb239160b3d854943128f4334822900534f2fe947930e5770", size = 2330317, upload-time = "2025-11-04T13:43:40.406Z" },
+    { url = "https://files.pythonhosted.org/packages/88/9d/b06ca6acfe4abb296110fb1273a4d848a0bfb2ff65f3ee92127b3244e16b/pydantic_core-2.41.5-pp311-pypy311_pp73-musllinux_1_1_x86_64.whl", hash = "sha256:f14f8f046c14563f8eb3f45f499cc658ab8d10072961e07225e507adb700e93f", size = 2316992, upload-time = "2025-11-04T13:43:43.602Z" },
+    { url = "https://files.pythonhosted.org/packages/36/c7/cfc8e811f061c841d7990b0201912c3556bfeb99cdcb7ed24adc8d6f8704/pydantic_core-2.41.5-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:56121965f7a4dc965bff783d70b907ddf3d57f6eba29b6d2e5dabfaf07799c51", size = 2145302, upload-time = "2025-11-04T13:43:46.64Z" },
+]
+
+[[package]]
+name = "pydantic-xml"
+version = "2.19.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pydantic" },
+    { name = "pydantic-core" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/b8/cb/5f80b61d73a8d6171ee4611bfd2b944c036c6f6e5f6e01d9fb02f29d7bfc/pydantic_xml-2.19.0.tar.gz", hash = "sha256:b7acba5a0966cbbbc9bf88d0d870b2bc875da063fe1bbe62d83939b549224730", size = 26228, upload-time = "2026-02-14T17:33:53.368Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/27/2d/dce0dc471fade04829c2948462d79c9bc4991305b0f73889f70c9645e540/pydantic_xml-2.19.0-py3-none-any.whl", hash = "sha256:42854bf962758bec338c112c2de984723708262793e108416f33aa4d6c11b3b4", size = 42536, upload-time = "2026-02-14T17:33:54.206Z" },
 ]
 
 [[package]]
@@ -581,6 +744,18 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/72/94/1a15dd82efb362ac84269196e94cf00f187f7ed21c242792a923cdb1c61f/typing_extensions-4.15.0.tar.gz", hash = "sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466", size = 109391, upload-time = "2025-08-25T13:49:26.313Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/18/67/36e9267722cc04a6b9f15c7f3441c2363321a3ea07da7ae0c0707beb2a9c/typing_extensions-4.15.0-py3-none-any.whl", hash = "sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548", size = 44614, upload-time = "2025-08-25T13:49:24.86Z" },
+]
+
+[[package]]
+name = "typing-inspection"
+version = "0.4.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/55/e3/70399cb7dd41c10ac53367ae42139cf4b1ca5f36bb3dc6c9d33acdb43655/typing_inspection-0.4.2.tar.gz", hash = "sha256:ba561c48a67c5958007083d386c3295464928b01faa735ab8547c5692e87f464", size = 75949, upload-time = "2025-10-01T02:14:41.687Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/dc/9b/47798a6c91d8bdb567fe2698fe81e0c6b7cb7ef4d13da4114b41d239f65d/typing_inspection-0.4.2-py3-none-any.whl", hash = "sha256:4ed1cacbdc298c220f1bd249ed5287caa16f34d44ef4e9c3d0cbad5b521545e7", size = 14611, upload-time = "2025-10-01T02:14:40.154Z" },
 ]
 
 [[package]]

--- a/uv.lock
+++ b/uv.lock
@@ -311,7 +311,7 @@ wheels = [
 
 [[package]]
 name = "pybeerxml"
-version = "2.1.2"
+version = "2.2.0"
 source = { editable = "." }
 
 [package.dev-dependencies]


### PR DESCRIPTION
## Summary
- migrate BeerXML models to `pydantic` + `pydantic-xml`
- add a class-based `Serializer` alongside `Parser` and align the public API around those entry points
- preserve recipe calculation behavior and compatibility aliases for stored XML-backed fields
- expand README and docs with serialization usage and API reference updates
- add serializer-focused test coverage and update dependencies in `pyproject.toml` and `uv.lock`

## Testing
- `uv run pytest -q tests/test_serializer.py tests/test_parser.py tests/test_recipe.py tests/test_utils.py tests/test_hop.py tests/test_fermentable.py`
- `uv run ruff check pybeerxml tests/test_serializer.py README.md docs`
- `uv run ty check pybeerxml`

Fixes #26 