### PR TITLE
Migrate models to pydantic-xml and add Serializer

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -23,6 +23,10 @@ var/
 .installed.cfg
 *.egg
 
+# MacOS
+.DS_Store
+
+
 # PyInstaller
 #  Usually these files are written by a python script from a template
 #  before PyInstaller builds the exe, so as to inject date/other infos into it.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # pybeerxml
 
-A simple BeerXML parser for Python
+A simple BeerXML parser and serializer for Python
 
 [![PyPi Version](https://img.shields.io/pypi/v/pybeerxml.svg?style=flat-square)](https://pypi.python.org/pypi?:action=display&name=pybeerxml)
 [![Build Status](https://img.shields.io/github/actions/workflow/status/hotzenklotz/pybeerxml/test_lint.yaml?branch=master&style=flat-square)](https://github.com/hotzenklotz/pybeerxml/actions/workflows/test_lint.yaml)
@@ -10,7 +10,8 @@ A simple BeerXML parser for Python
 
 Parses all recipes within a BeerXML file and returns `Recipe` objects containing all ingredients,
 style information and metadata. OG, FG, ABV and IBU are calculated from the ingredient list. (your
-milage may vary)
+milage may vary). Recipes can also be serialized back to BeerXML. All models are built on
+[pydantic](https://docs.pydantic.dev/) and [pydantic-xml](https://pydantic-xml.readthedocs.io/).
 
 ## Installation
 
@@ -54,6 +55,43 @@ for recipe in recipes:
 
     for misc in recipe.miscs:
         print(misc.name)
+```
+
+## Serialization
+
+Write recipes back to BeerXML with the `Serializer` class. Only values stored in the XML-backed
+fields are written — calculated properties (`og_calculated`, `og_plato`, etc.) are never serialized.
+The stored values for OG, FG, IBU, ABV and color live in the trailing-underscore fields `og_`,
+`fg_`, `ibu_`, `abv_` and `color_`.
+
+```
+from pybeerxml import Parser, Serializer
+
+parser = Parser()
+recipes = parser.parse("/tmp/SimcoeIPA.beerxml")
+
+serializer = Serializer()
+
+# write to a file
+serializer.serialize(recipes, "/tmp/SimcoeIPA-copy.beerxml")
+
+# or to a string
+xml_string = serializer.serialize_to_string(recipes)
+```
+
+Since all models are pydantic models, you can also build recipes programmatically:
+
+```
+from pybeerxml import Serializer
+from pybeerxml.recipe import Recipe
+from pybeerxml.hop import Hop
+
+recipe = Recipe(name="My IPA", batch_size=20.0)
+recipe.hops.append(Hop(name="Simcoe", alpha=13.0, amount=0.05, use="boil", time=60))
+
+print(recipe.og_calculated)
+
+xml_string = Serializer().serialize_to_string(recipe)
 ```
 
 ## Testing

--- a/README.md
+++ b/README.md
@@ -72,11 +72,11 @@ recipes = parser.parse("/tmp/SimcoeIPA.beerxml")
 
 serializer = Serializer()
 
-# write to a file
-serializer.serialize(recipes, "/tmp/SimcoeIPA-copy.beerxml")
+# serialize to a string
+xml_string = serializer.serialize(recipes)
 
-# or to a string
-xml_string = serializer.serialize_to_string(recipes)
+# or write to a file
+serializer.write(recipes, "/tmp/SimcoeIPA-copy.beerxml")
 ```
 
 Since all models are pydantic models, you can also build recipes programmatically:
@@ -91,7 +91,7 @@ recipe.hops.append(Hop(name="Simcoe", alpha=13.0, amount=0.05, use="boil", time=
 
 print(recipe.og_calculated)
 
-xml_string = Serializer().serialize_to_string(recipe)
+xml_string = recipe.to_xml_string()
 ```
 
 ## Testing

--- a/docs/api/index.md
+++ b/docs/api/index.md
@@ -5,13 +5,14 @@ description: Full API reference for pybeerxml
 
 # API Reference
 
-pybeerxml exposes one entry point — the `Parser` class — which returns `Recipe` objects. Each `Recipe` holds typed ingredient and metadata objects.
+pybeerxml exposes two entry points — the `Parser` and `Serializer` classes — which convert between BeerXML documents and `Recipe` objects. Each `Recipe` holds typed ingredient and metadata objects. All models are [pydantic-xml](https://pydantic-xml.readthedocs.io/) models, so they can be validated, constructed programmatically, and serialized.
 
 ## Class overview
 
 | Class | Description |
 |-------|-------------|
 | [`Parser`](parser.md) | Reads BeerXML files or strings and returns `Recipe` objects |
+| [`Serializer`](serializer.md) | Writes `Recipe` objects to BeerXML files or strings |
 | [`Recipe`](recipe.md) | A complete beer recipe with calculated properties |
 | [`Fermentable`](fermentable.md) | A grain, extract, sugar, or adjunct |
 | [`Hop`](hop.md) | A hop addition with bitterness calculation |
@@ -25,7 +26,8 @@ pybeerxml exposes one entry point — the `Parser` class — which returns `Reci
 ## Import paths
 
 ```python
-from pybeerxml import Parser          # main entry point
+from pybeerxml import Parser            # main entry points
+from pybeerxml import Serializer
 from pybeerxml.recipe import Recipe
 from pybeerxml.fermentable import Fermentable
 from pybeerxml.hop import Hop
@@ -37,3 +39,15 @@ from pybeerxml.style import Style
 from pybeerxml.water import Water
 from pybeerxml.equipment import Equipment
 ```
+
+## Stored vs. calculated values
+
+The five brewing metrics expose the stored XML value separately from the calculated one. The trailing-underscore fields hold the raw XML values and are the only ones serialized:
+
+| Fallback property | Stored field (serialized) | Calculated property |
+|-------------------|---------------------------|---------------------|
+| `recipe.og` | `recipe.og_` | `recipe.og_calculated` |
+| `recipe.fg` | `recipe.fg_` | `recipe.fg_calculated` |
+| `recipe.ibu` | `recipe.ibu_` | `recipe.ibu_calculated` |
+| `recipe.abv` | `recipe.abv_` | `recipe.abv_calculated` |
+| `recipe.color` | `recipe.color_` | `recipe.color_calculated` |

--- a/docs/api/serializer.md
+++ b/docs/api/serializer.md
@@ -1,0 +1,3 @@
+# Serializer
+
+::: pybeerxml.serializer.Serializer

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -88,11 +88,11 @@ recipes = parser.parse("/path/to/recipe.beerxml")
 
 serializer = Serializer()
 
-# Write to a file
-serializer.serialize(recipes, "/path/to/copy.beerxml")
+# Serialize to a string
+xml_string = serializer.serialize(recipes)
 
-# Or to a string
-xml_string = serializer.serialize_to_string(recipes)
+# Or write to a file
+serializer.write(recipes, "/path/to/copy.beerxml")
 ```
 
 Since all models are pydantic models, recipes can be built programmatically and serialized:
@@ -107,7 +107,7 @@ recipe.hops.append(Hop(name="Simcoe", alpha=13.0, amount=0.05, use="boil", time=
 
 print(recipe.og_calculated)   # calculated from the ingredient list
 
-xml_string = Serializer().serialize_to_string(recipe)
+xml_string = recipe.to_xml_string()
 ```
 
 Fields left as `None` are omitted from the output, and boolean fields are emitted as `TRUE` / `FALSE` per the BeerXML spec.

--- a/docs/getting-started.md
+++ b/docs/getting-started.md
@@ -53,17 +53,20 @@ BeerXML files may or may not include pre-calculated values for OG, FG, IBU, ABV,
 
 | Property | Stored value | Calculated fallback |
 |----------|-------------|---------------------|
-| `recipe.og` | From XML if present | `recipe.og_calculated` |
-| `recipe.fg` | From XML if present | `recipe.fg_calculated` |
-| `recipe.ibu` | From XML if present | `recipe.ibu_calculated` |
-| `recipe.abv` | From XML if present | `recipe.abv_calculated` |
-| `recipe.color` | From XML if present | `recipe.color_calculated` |
+| `recipe.og` | `recipe.og_` (from XML if present) | `recipe.og_calculated` |
+| `recipe.fg` | `recipe.fg_` (from XML if present) | `recipe.fg_calculated` |
+| `recipe.ibu` | `recipe.ibu_` (from XML if present) | `recipe.ibu_calculated` |
+| `recipe.abv` | `recipe.abv_` (from XML if present) | `recipe.abv_calculated` |
+| `recipe.color` | `recipe.color_` (from XML if present) | `recipe.color_calculated` |
 
-The plain properties (`recipe.og`, `recipe.ibu`, etc.) return the stored XML value when available, and automatically fall back to the calculated value otherwise. The `_calculated` variants always compute from ingredients regardless.
+The plain properties (`recipe.og`, `recipe.ibu`, etc.) return the stored XML value when available, and automatically fall back to the calculated value otherwise. The `_calculated` variants always compute from ingredients regardless. The trailing-underscore fields (`og_`, `fg_`, `ibu_`, `abv_`, `color_`) hold exactly the value stored in the XML — or `None` when the XML did not provide one — and are the only variants written back during serialization.
 
 ```python
 # Uses stored OG from XML, or calculates from fermentables if missing
 print(recipe.og)
+
+# The stored OG from the XML (None if absent)
+print(recipe.og_)
 
 # Always calculated from the fermentable bill
 print(recipe.og_calculated)
@@ -72,6 +75,42 @@ print(recipe.og_calculated)
 print(recipe.og_plato)
 print(recipe.og_calculated_plato)
 ```
+
+## Serializing recipes
+
+The `Serializer` class writes recipes back to BeerXML. Only stored values are serialized — calculated properties are never written to the XML.
+
+```python
+from pybeerxml import Parser, Serializer
+
+parser = Parser()
+recipes = parser.parse("/path/to/recipe.beerxml")
+
+serializer = Serializer()
+
+# Write to a file
+serializer.serialize(recipes, "/path/to/copy.beerxml")
+
+# Or to a string
+xml_string = serializer.serialize_to_string(recipes)
+```
+
+Since all models are pydantic models, recipes can be built programmatically and serialized:
+
+```python
+from pybeerxml import Serializer
+from pybeerxml.recipe import Recipe
+from pybeerxml.hop import Hop
+
+recipe = Recipe(name="My IPA", batch_size=20.0)
+recipe.hops.append(Hop(name="Simcoe", alpha=13.0, amount=0.05, use="boil", time=60))
+
+print(recipe.og_calculated)   # calculated from the ingredient list
+
+xml_string = Serializer().serialize_to_string(recipe)
+```
+
+Fields left as `None` are omitted from the output, and boolean fields are emitted as `TRUE` / `FALSE` per the BeerXML spec.
 
 ## Working with ingredients
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,6 +1,6 @@
 ---
 title: pybeerxml
-description: A BeerXML parser for Python
+description: A BeerXML parser and serializer for Python
 ---
 
 # pybeerxml
@@ -9,11 +9,13 @@ description: A BeerXML parser for Python
 [![Build Status](https://img.shields.io/github/actions/workflow/status/hotzenklotz/pybeerxml/test_lint.yaml?branch=master&style=flat-square)](https://github.com/hotzenklotz/pybeerxml/actions/workflows/test_lint.yaml)
 [![Docs](https://img.shields.io/badge/docs-pybeerxml.onrender.com-blue?style=flat-square)](https://pybeerxml.onrender.com/)
 
-**pybeerxml** is a Python library for parsing [BeerXML](http://www.beerxml.com/) recipe files. It reads all recipes from a `.beerxml` file and returns structured `Recipe` objects — including ingredients, style metadata, and automatically calculated values for OG, FG, ABV, IBU, and colour.
+**pybeerxml** is a Python library for parsing and serializing [BeerXML](http://www.beerxml.com/) recipe files. It reads all recipes from a `.beerxml` file and returns structured `Recipe` objects — including ingredients, style metadata, and automatically calculated values for OG, FG, ABV, IBU, and colour. All models are [pydantic](https://docs.pydantic.dev/) models with XML support via [pydantic-xml](https://pydantic-xml.readthedocs.io/), so recipes can be validated, modified, and written back to BeerXML.
 
 ## Features
 
 - Parse BeerXML files or XML strings
+- Serialize recipes back to BeerXML
+- Typed, validated models powered by pydantic and pydantic-xml
 - Access hops, fermentables, yeasts, miscs, mash steps, equipment, and style
 - Automatic calculation of OG, FG, ABV, IBU, and colour when not provided in the XML
 - Supports both Tinseth and Rager IBU formulas

--- a/pybeerxml/__init__.py
+++ b/pybeerxml/__init__.py
@@ -1,3 +1,4 @@
 from pybeerxml.parser import Parser
+from pybeerxml.serializer import Serializer
 
-__all__ = ["Parser"]
+__all__ = ["Parser", "Serializer"]

--- a/pybeerxml/base.py
+++ b/pybeerxml/base.py
@@ -1,0 +1,32 @@
+from typing import Annotated, Any
+
+from pydantic import ConfigDict, Field, field_serializer
+from pydantic_xml import BaseXmlModel
+from pydantic_xml.model import SearchMode
+
+#: A float field that tolerates non-numeric XML content (e.g. ``<GRAIN_TEMP>unknown</GRAIN_TEMP>``).
+#: Numeric strings are coerced to ``float``; anything else is kept as a string.
+LenientFloat = Annotated[float | str | None, Field(union_mode="left_to_right")]
+
+#: An int field that tolerates non-numeric XML content (e.g. alphanumeric yeast product ids).
+#: Numeric strings are coerced to ``int``; anything else is kept as a string.
+LenientInt = Annotated[int | str | None, Field(union_mode="left_to_right")]
+
+
+class BeerXmlModel(BaseXmlModel, search_mode=SearchMode.UNORDERED):
+    """Shared base class for all BeerXML models.
+
+    Uses the ``unordered`` search mode so that XML elements may appear in any
+    order (real-world BeerXML writers do not follow a fixed field order).
+    Enables validation on attribute assignment so that assigning raw BeerXML
+    strings (e.g. ``"TRUE"``) is coerced the same way as during parsing, and
+    serializes boolean fields as ``TRUE`` / ``FALSE`` per the BeerXML spec.
+    """
+
+    model_config = ConfigDict(validate_assignment=True)
+
+    @field_serializer("*", when_used="always")
+    def _serialize_bool(self, value: Any) -> Any:
+        if isinstance(value, bool):
+            return "TRUE" if value else "FALSE"
+        return value

--- a/pybeerxml/equipment.py
+++ b/pybeerxml/equipment.py
@@ -1,11 +1,9 @@
-from dataclasses import dataclass, field
-from typing import Any
+from pydantic_xml import element
 
-from pybeerxml.utils import cast_to_bool
+from pybeerxml.base import BeerXmlModel, LenientFloat
 
 
-@dataclass
-class Equipment:
+class Equipment(BeerXmlModel, tag="EQUIPMENT"):
     """Brewing equipment profile from a BeerXML ``<EQUIPMENT>`` element.
 
     Attributes:
@@ -19,34 +17,27 @@ class Equipment:
         trub_chiller_loss: Volume lost to trub and chiller deadspace in litres.
         evap_rate: Evaporation rate in litres per hour.
         boil_time: Boil duration in minutes.
+        calc_boil_volume: Whether the pre-boil volume should be calculated from
+            equipment parameters.
         lauter_deadspace: Volume lost in the lauter tun in litres.
         top_up_kettle: Water added to the kettle before the boil in litres.
         hop_utilization: Global hop utilization multiplier (%).
         notes: Free-text notes.
     """
 
-    name: str | None = None
-    version: int | None = None
-    boil_size: float | None = None
-    batch_size: float | None = None
-    tun_volume: float | None = None
-    tun_weight: float | None = None
-    tun_specific_heat: float | None = None
-    top_up_water: float | None = None
-    trub_chiller_loss: float | None = None
-    evap_rate: float | None = None
-    boil_time: float | None = None
-    lauter_deadspace: float | None = None
-    top_up_kettle: float | None = None
-    hop_utilization: float | None = None
-    notes: str | None = None
-    _calc_boil_volume: bool | None = field(default=None, init=False, repr=False)
-
-    @property
-    def calc_boil_volume(self) -> bool | None:
-        """Whether the pre-boil volume should be calculated from equipment parameters."""
-        return self._calc_boil_volume
-
-    @calc_boil_volume.setter
-    def calc_boil_volume(self, value: Any) -> None:
-        self._calc_boil_volume = cast_to_bool(value)
+    name: str | None = element(tag="NAME", default=None)
+    version: int | None = element(tag="VERSION", default=None)
+    boil_size: LenientFloat = element(tag="BOIL_SIZE", default=None)
+    batch_size: LenientFloat = element(tag="BATCH_SIZE", default=None)
+    tun_volume: LenientFloat = element(tag="TUN_VOLUME", default=None)
+    tun_weight: LenientFloat = element(tag="TUN_WEIGHT", default=None)
+    tun_specific_heat: LenientFloat = element(tag="TUN_SPECIFIC_HEAT", default=None)
+    top_up_water: LenientFloat = element(tag="TOP_UP_WATER", default=None)
+    trub_chiller_loss: LenientFloat = element(tag="TRUB_CHILLER_LOSS", default=None)
+    evap_rate: LenientFloat = element(tag="EVAP_RATE", default=None)
+    boil_time: LenientFloat = element(tag="BOIL_TIME", default=None)
+    calc_boil_volume: bool | None = element(tag="CALC_BOIL_VOLUME", default=None)
+    lauter_deadspace: LenientFloat = element(tag="LAUTER_DEADSPACE", default=None)
+    top_up_kettle: LenientFloat = element(tag="TOP_UP_KETTLE", default=None)
+    hop_utilization: LenientFloat = element(tag="HOP_UTILIZATION", default=None)
+    notes: str | None = element(tag="NOTES", default=None)

--- a/pybeerxml/fermentable.py
+++ b/pybeerxml/fermentable.py
@@ -1,9 +1,9 @@
 import logging
 import re
-from dataclasses import dataclass, field
-from typing import Any
 
-from pybeerxml.utils import cast_to_bool
+from pydantic_xml import element
+
+from pybeerxml.base import BeerXmlModel, LenientFloat
 
 logger = logging.getLogger(__name__)
 
@@ -17,9 +17,12 @@ STEEP = re.compile(r"biscuit|black|cara|chocolate|crystal|munich|roast|special|t
 BOIL = re.compile(r"candi|candy|dme|dry|extract|honey|lme|liquid|sugar|syrup|turbinado", re.IGNORECASE)
 
 
-@dataclass
-class Fermentable:
+class Fermentable(BeerXmlModel, tag="FERMENTABLE"):
     """A fermentable ingredient — grain, extract, sugar, or adjunct.
+
+    The BeerXML ``YIELD`` field is stored in the ``yield_`` attribute (``yield``
+    is a Python keyword). The old ``_yield`` attribute remains available as a
+    compatibility alias.
 
     Attributes:
         name: Ingredient name.
@@ -35,35 +38,38 @@ class Fermentable:
         protein: Protein content (%).
         max_in_batch: Maximum recommended percentage of the grain bill.
         ibu_gal_per_lb: IBU contribution per gallon per pound (for adjuncts).
+        yield_: The BeerXML ``YIELD`` field (dry yield percentage).
+        add_after_boil: Whether this fermentable is added after the boil.
+        recommend_mash: Whether mashing is recommended for this fermentable.
     """
 
-    name: str | None = None
-    amount: float | None = None
-    color: float | None = None
-    version: int | None = None
-    type: str | None = None
-    origin: str | None = None
-    supplier: str | None = None
-    notes: str | None = None
-    coarse_fine_diff: float | None = None
-    moisture: float | None = None
-    diastatic_power: float | None = None
-    protein: float | None = None
-    max_in_batch: float | None = None
-    ibu_gal_per_lb: float | None = None
-    # "yield" is a Python keyword, so the parser maps it to _yield via setattr
-    _yield: float | None = field(default=None, init=False, repr=False)
-    _add_after_boil: bool | None = field(default=None, init=False, repr=False)
-    _recommend_mash: bool | None = field(default=None, init=False, repr=False)
+    name: str | None = element(tag="NAME", default=None)
+    amount: float | None = element(tag="AMOUNT", default=None)
+    color: float | None = element(tag="COLOR", default=None)
+    version: int | None = element(tag="VERSION", default=None)
+    type: str | None = element(tag="TYPE", default=None)
+    origin: str | None = element(tag="ORIGIN", default=None)
+    supplier: str | None = element(tag="SUPPLIER", default=None)
+    notes: str | None = element(tag="NOTES", default=None)
+    coarse_fine_diff: LenientFloat = element(tag="COARSE_FINE_DIFF", default=None)
+    moisture: LenientFloat = element(tag="MOISTURE", default=None)
+    diastatic_power: LenientFloat = element(tag="DIASTATIC_POWER", default=None)
+    protein: LenientFloat = element(tag="PROTEIN", default=None)
+    max_in_batch: LenientFloat = element(tag="MAX_IN_BATCH", default=None)
+    ibu_gal_per_lb: LenientFloat = element(tag="IBU_GAL_PER_LB", default=None)
+    # "yield" is a Python keyword, so the XML YIELD field is stored as yield_
+    yield_: float | None = element(tag="YIELD", default=None)
+    add_after_boil: bool | None = element(tag="ADD_AFTER_BOIL", default=False)
+    recommend_mash: bool | None = element(tag="RECOMMEND_MASH", default=None)
 
     @property
-    def add_after_boil(self) -> bool:
-        """Whether this fermentable is added after the boil (e.g. honey in secondary)."""
-        return bool(self._add_after_boil)
+    def _yield(self) -> float | None:
+        """Compatibility alias for `yield_`."""
+        return self.yield_
 
-    @add_after_boil.setter
-    def add_after_boil(self, value: Any) -> None:
-        self._add_after_boil = cast_to_bool(value)
+    @_yield.setter
+    def _yield(self, value: float | None) -> None:
+        self.yield_ = value
 
     @property
     def ppg(self) -> float | None:
@@ -71,8 +77,8 @@ class Fermentable:
 
         Returns ``None`` when ``YIELD`` is not set.
         """
-        if self._yield is not None:
-            return 0.46214 * self._yield
+        if self.yield_ is not None:
+            return 0.46214 * self.yield_
         logger.error("Property 'ppg' could not be calculated because property 'yield' is missing. Default to 'None'")
         return None
 
@@ -123,12 +129,3 @@ class Fermentable:
         weight_lb = self.amount * 2.20462
         volume_gallons = liters * 0.264172
         return self.ppg * weight_lb / volume_gallons
-
-    @property
-    def recommend_mash(self) -> bool | None:
-        """Whether mashing is recommended for this fermentable."""
-        return self._recommend_mash
-
-    @recommend_mash.setter
-    def recommend_mash(self, value: Any) -> None:
-        self._recommend_mash = cast_to_bool(value)

--- a/pybeerxml/hop.py
+++ b/pybeerxml/hop.py
@@ -1,7 +1,11 @@
 import math
 
+from pydantic_xml import element
 
-class Hop:
+from pybeerxml.base import BeerXmlModel, LenientFloat
+
+
+class Hop(BeerXmlModel, tag="HOP"):
     """A hop addition in a beer recipe.
 
     Attributes:
@@ -17,24 +21,23 @@ class Hop:
         notes: Free-text notes.
     """
 
-    def __init__(self):
-        self.name: str | None = None
-        self.alpha: float | None = None
-        self.amount: float | None = None
-        self.use: str | None = None
-        self.form: str | None = None
-        self.notes: str | None = None
-        self.time: float | None = None
-        self.version: int | None = None
-        self.type: str | None = None
-        self.beta: float | None = None
-        self.hsi: float | None = None
-        self.origin: str | None = None
-        self.substitutes: str | None = None
-        self.humulene: float | None = None
-        self.caryophyllene: float | None = None
-        self.cohumulone: float | None = None
-        self.myrcene: float | None = None
+    name: str | None = element(tag="NAME", default=None)
+    alpha: float | None = element(tag="ALPHA", default=None)
+    amount: float | None = element(tag="AMOUNT", default=None)
+    use: str | None = element(tag="USE", default=None)
+    form: str | None = element(tag="FORM", default=None)
+    notes: str | None = element(tag="NOTES", default=None)
+    time: float | None = element(tag="TIME", default=None)
+    version: int | None = element(tag="VERSION", default=None)
+    type: str | None = element(tag="TYPE", default=None)
+    beta: LenientFloat = element(tag="BETA", default=None)
+    hsi: LenientFloat = element(tag="HSI", default=None)
+    origin: str | None = element(tag="ORIGIN", default=None)
+    substitutes: str | None = element(tag="SUBSTITUTES", default=None)
+    humulene: LenientFloat = element(tag="HUMULENE", default=None)
+    caryophyllene: LenientFloat = element(tag="CARYOPHYLLENE", default=None)
+    cohumulone: LenientFloat = element(tag="COHUMULONE", default=None)
+    myrcene: LenientFloat = element(tag="MYRCENE", default=None)
 
     def utilization_factor(self) -> float:
         """Utilization multiplier for hop form.

--- a/pybeerxml/mash.py
+++ b/pybeerxml/mash.py
@@ -1,43 +1,34 @@
-from dataclasses import dataclass, field
-from typing import Any
+from pydantic_xml import element, wrapped
 
+from pybeerxml.base import BeerXmlModel, LenientFloat
 from pybeerxml.mash_step import MashStep
-from pybeerxml.utils import cast_to_bool
 
 
-@dataclass
-class Mash:
+class Mash(BeerXmlModel, tag="MASH"):
     """A mash profile, including temperature steps.
 
     Attributes:
         name: Profile name.
-        grain_temp: Initial grain temperature in °C.
+        grain_temp: Initial grain temperature in °C. Non-numeric XML values
+            (e.g. ``"unknown"``) are kept as strings.
         sparge_temp: Sparge water temperature in °C.
         ph: Target mash pH.
         notes: Free-text notes.
         tun_temp: Mash tun temperature in °C.
         tun_weight: Mash tun weight in kg.
         tun_specific_heat: Specific heat of the mash tun material in Cal/(g·°C).
+        equip_adjust: Whether mash temperatures are adjusted for equipment heat capacity.
         steps: Ordered list of mash temperature steps.
     """
 
-    name: str | None = None
-    version: int | None = None
-    grain_temp: float | None = None
-    sparge_temp: float | None = None
-    ph: float | None = None
-    notes: str | None = None
-    tun_temp: float | None = None
-    tun_weight: float | None = None
-    tun_specific_heat: float | None = None
-    steps: list[MashStep] = field(default_factory=list)
-    _equip_adjust: bool | None = field(default=None, init=False, repr=False)
-
-    @property
-    def equip_adjust(self) -> bool | None:
-        """Whether mash temperatures are adjusted for equipment heat capacity."""
-        return self._equip_adjust
-
-    @equip_adjust.setter
-    def equip_adjust(self, value: Any) -> None:
-        self._equip_adjust = cast_to_bool(value)
+    name: str | None = element(tag="NAME", default=None)
+    version: int | None = element(tag="VERSION", default=None)
+    grain_temp: LenientFloat = element(tag="GRAIN_TEMP", default=None)
+    sparge_temp: LenientFloat = element(tag="SPARGE_TEMP", default=None)
+    ph: LenientFloat = element(tag="PH", default=None)
+    notes: str | None = element(tag="NOTES", default=None)
+    tun_temp: LenientFloat = element(tag="TUN_TEMP", default=None)
+    tun_weight: LenientFloat = element(tag="TUN_WEIGHT", default=None)
+    tun_specific_heat: LenientFloat = element(tag="TUN_SPECIFIC_HEAT", default=None)
+    equip_adjust: bool | None = element(tag="EQUIP_ADJUST", default=None)
+    steps: list[MashStep] = wrapped("MASH_STEPS", element(tag="MASH_STEP"), default_factory=list)

--- a/pybeerxml/mash_step.py
+++ b/pybeerxml/mash_step.py
@@ -1,4 +1,9 @@
-class MashStep:
+from pydantic_xml import element
+
+from pybeerxml.base import BeerXmlModel, LenientFloat
+
+
+class MashStep(BeerXmlModel, tag="MASH_STEP"):
     """A single temperature step within a mash profile.
 
     Attributes:
@@ -11,15 +16,14 @@ class MashStep:
         decoction_amt: Volume of mash removed for decoction (decoction steps only).
     """
 
-    def __init__(self):
-        self.name: str | None = None
-        self.type: str | None = None
-        self.infuse_amount: float | None = None
-        self.step_temp: float | None = None
-        self.end_temp: float | None = None
-        self.step_time: float | None = None
-        self.decoction_amt: str | None = None
-        self.version: int | None = None
+    name: str | None = element(tag="NAME", default=None)
+    type: str | None = element(tag="TYPE", default=None)
+    infuse_amount: LenientFloat = element(tag="INFUSE_AMOUNT", default=None)
+    step_temp: LenientFloat = element(tag="STEP_TEMP", default=None)
+    end_temp: LenientFloat = element(tag="END_TEMP", default=None)
+    step_time: LenientFloat = element(tag="STEP_TIME", default=None)
+    decoction_amt: str | None = element(tag="DECOCTION_AMT", default=None)
+    version: int | None = element(tag="VERSION", default=None)
 
     @property
     def water_ratio(self):

--- a/pybeerxml/misc.py
+++ b/pybeerxml/misc.py
@@ -1,9 +1,9 @@
-from typing import Any
+from pydantic_xml import element
 
-from pybeerxml.utils import cast_to_bool
+from pybeerxml.base import BeerXmlModel, LenientFloat
 
 
-class Misc:
+class Misc(BeerXmlModel, tag="MISC"):
     """A miscellaneous ingredient — finings, spices, water agents, etc.
 
     Attributes:
@@ -13,6 +13,8 @@ class Misc:
             ``"Herb"``, ``"Flavor"``, or ``"Other"``.
         amount: Quantity — weight in kg or volume in litres depending on
             ``amount_is_weight``.
+        amount_is_weight: ``True`` if ``amount`` is measured by weight (kg),
+            ``False`` if by volume (L).
         use: When the ingredient is added — ``"Boil"``, ``"Mash"``,
             ``"Primary"``, ``"Secondary"``, or ``"Bottling"``.
         use_for: Description of the ingredient's purpose.
@@ -20,22 +22,12 @@ class Misc:
         notes: Free-text notes.
     """
 
-    def __init__(self):
-        self.name: str | None = None
-        self.version: int | None = None
-        self.type: str | None = None
-        self.amount: float | None = None
-        self._amount_is_weight: bool | None = False
-        self.use: str | None = None
-        self.use_for: str | None = None
-        self.time: float | None = None
-        self.notes: str | None = None
-
-    @property
-    def amount_is_weight(self) -> bool | None:
-        """``True`` if ``amount`` is measured by weight (kg), ``False`` if by volume (L)."""
-        return self._amount_is_weight
-
-    @amount_is_weight.setter
-    def amount_is_weight(self, value: Any):
-        self._amount_is_weight = cast_to_bool(value)
+    name: str | None = element(tag="NAME", default=None)
+    version: int | None = element(tag="VERSION", default=None)
+    type: str | None = element(tag="TYPE", default=None)
+    amount: LenientFloat = element(tag="AMOUNT", default=None)
+    amount_is_weight: bool | None = element(tag="AMOUNT_IS_WEIGHT", default=False)
+    use: str | None = element(tag="USE", default=None)
+    use_for: str | None = element(tag="USE_FOR", default=None)
+    time: LenientFloat = element(tag="TIME", default=None)
+    notes: str | None = element(tag="NOTES", default=None)

--- a/pybeerxml/parser.py
+++ b/pybeerxml/parser.py
@@ -3,33 +3,20 @@ from __future__ import annotations
 import logging
 from typing import Any
 from xml.etree import ElementTree
-from xml.etree.ElementTree import Element
 
-from pybeerxml.equipment import Equipment
-from pybeerxml.fermentable import Fermentable
-from pybeerxml.hop import Hop
-from pybeerxml.mash import Mash
-from pybeerxml.mash_step import MashStep
-from pybeerxml.misc import Misc
-from pybeerxml.recipe import Recipe
-from pybeerxml.style import Style
-from pybeerxml.utils import to_lower
-from pybeerxml.water import Water
-from pybeerxml.yeast import Yeast
+from pybeerxml.recipe import Recipe, Recipes
+
+__all__ = ["Parser", "Recipe"]
 
 logger = logging.getLogger(__name__)
-
-BeerXMLObject = Recipe | Mash | Yeast | Fermentable | Hop | Misc | MashStep | Style | Water | Equipment
-INTEGER_FIELDS = {"version", "fermentation_stages", "times_cultured", "max_reuse"}
-TEXT_FIELDS = {"category_number"}
 
 
 class Parser:
     """Reads BeerXML files or strings and returns a list of `Recipe` objects.
 
-    A single BeerXML document may contain multiple `<RECIPE>` elements; all
-    three parse methods always return a list.  Unknown XML fields are logged at
-    ``ERROR`` level and silently ignored so that non-standard files do not raise.
+    A single BeerXML document may contain multiple ``<RECIPE>`` elements; all
+    parse methods always return a list.  Unknown XML fields are silently
+    ignored so that non-standard files do not raise.
 
     Examples:
         >>> from pybeerxml import Parser
@@ -38,55 +25,6 @@ class Parser:
         >>> for recipe in recipes:
         ...     print(recipe.name, recipe.og)
     """
-
-    def nodes_to_object(self, nodes: Element, beerxml_object: BeerXMLObject) -> None:
-        """Map all child XML nodes onto an object's attributes.
-
-        Args:
-            nodes: Parent XML element whose children will be mapped.
-            beerxml_object: Target object to receive the attribute values.
-        """
-        for node in nodes:
-            self.node_to_object(node, beerxml_object)
-
-    def node_to_object(self, node: Element, beerxml_object: BeerXMLObject) -> None:
-        """Map a single XML node onto an object attribute.
-
-        The node tag is lower-cased and used as the attribute name.  Numeric
-        string values are coerced to ``float`` automatically.  The BeerXML
-        field ``YIELD`` is mapped to ``_yield`` because ``yield`` is a Python
-        keyword.
-
-        Args:
-            node: XML element to map.
-            beerxml_object: Target object to receive the attribute value.
-        """
-        attribute = to_lower(node.tag)
-        attribute = "_yield" if attribute == "yield" else attribute
-
-        value: str | float | int | None = node.text or None
-
-        if value is not None:
-            if attribute in TEXT_FIELDS:
-                pass
-            elif attribute in INTEGER_FIELDS:
-                try:
-                    value = int(value)
-                except ValueError:
-                    try:
-                        value = int(float(value))
-                    except ValueError:
-                        pass
-            else:
-                try:
-                    value = float(value)
-                except ValueError:
-                    pass
-
-            try:
-                setattr(beerxml_object, attribute, value)
-            except AttributeError:
-                logger.error("Attribute %s not supported.", attribute)
 
     def parse_from_string(self, xml_string: str) -> list[Recipe]:
         """Parse BeerXML content from a string.
@@ -98,10 +36,10 @@ class Parser:
             A list of `Recipe` objects found in the document.
 
         Raises:
-            xml.etree.ElementTree.ParseError: If ``xml_string`` is not valid XML.
+            pydantic_core._pydantic_core.ValidationError: If ``xml_string`` is
+                not valid XML or does not match the BeerXML schema.
         """
-        tree = ElementTree.ElementTree(ElementTree.fromstring(xml_string))
-        return self.parse_tree(tree)
+        return Recipes.from_xml(xml_string).recipes
 
     def parse(self, xml_file: str) -> list[Recipe]:
         """Parse a BeerXML file from disk.
@@ -114,11 +52,11 @@ class Parser:
 
         Raises:
             FileNotFoundError: If ``xml_file`` does not exist.
-            xml.etree.ElementTree.ParseError: If the file is not valid XML.
+            pydantic_core._pydantic_core.ValidationError: If the file is not
+                valid XML or does not match the BeerXML schema.
         """
         with open(xml_file, "rt") as file:
-            tree = ElementTree.parse(file)
-        return self.parse_tree(tree)
+            return self.parse_from_string(file.read())
 
     def parse_tree(self, tree: ElementTree.ElementTree[Any]) -> list[Recipe]:
         """Parse an already-constructed ``ElementTree``.
@@ -132,81 +70,5 @@ class Parser:
         Returns:
             A list of `Recipe` objects found in the tree.
         """
-        recipes = []
-        for recipe_node in tree.iter():
-            if to_lower(recipe_node.tag) != "recipe":
-                continue
-            recipe = self.parse_recipe(recipe_node)
-            recipes.append(recipe)
-        return recipes
-
-    def parse_recipe(self, recipe_node: Element) -> Recipe:
-        """Parse a single ``<RECIPE>`` element into a `Recipe` object.
-
-        Args:
-            recipe_node: The ``<RECIPE>`` XML element.
-
-        Returns:
-            A populated `Recipe` instance.
-        """
-        recipe = Recipe()
-
-        for recipe_property in recipe_node:
-            tag_name = to_lower(recipe_property.tag)
-
-            if tag_name == "fermentables":
-                for fermentable_node in recipe_property:
-                    fermentable = Fermentable()
-                    self.nodes_to_object(fermentable_node, fermentable)
-                    recipe.fermentables.append(fermentable)
-
-            elif tag_name == "yeasts":
-                for yeast_node in recipe_property:
-                    yeast = Yeast()
-                    self.nodes_to_object(yeast_node, yeast)
-                    recipe.yeasts.append(yeast)
-
-            elif tag_name == "hops":
-                for hop_node in recipe_property:
-                    hop = Hop()
-                    self.nodes_to_object(hop_node, hop)
-                    recipe.hops.append(hop)
-
-            elif tag_name == "miscs":
-                for misc_node in recipe_property:
-                    misc = Misc()
-                    self.nodes_to_object(misc_node, misc)
-                    recipe.miscs.append(misc)
-
-            elif tag_name == "style":
-                style = Style()
-                recipe.style = style
-                self.nodes_to_object(recipe_property, style)
-
-            elif tag_name == "waters":
-                for water_node in recipe_property:
-                    water = Water()
-                    self.nodes_to_object(water_node, water)
-                    recipe.waters.append(water)
-
-            elif tag_name == "equipment":
-                equipment = Equipment()
-                recipe.equipment = equipment
-                self.nodes_to_object(recipe_property, equipment)
-
-            elif tag_name == "mash":
-                mash = Mash()
-                recipe.mash = mash
-                for mash_node in recipe_property:
-                    if to_lower(mash_node.tag) == "mash_steps":
-                        for mash_step_node in mash_node:
-                            mash_step = MashStep()
-                            self.nodes_to_object(mash_step_node, mash_step)
-                            mash.steps.append(mash_step)
-                    else:
-                        self.node_to_object(mash_node, mash)
-
-            else:
-                self.node_to_object(recipe_property, recipe)
-
-        return recipe
+        xml_string = ElementTree.tostring(tree.getroot(), encoding="unicode")
+        return self.parse_from_string(xml_string)

--- a/pybeerxml/recipe.py
+++ b/pybeerxml/recipe.py
@@ -1,4 +1,5 @@
 import logging
+from xml.etree.ElementTree import Element
 
 from pydantic_xml import element, wrapped
 
@@ -355,6 +356,24 @@ class Recipe(BeerXmlModel, tag="RECIPE"):
                 # 8.3454 is conversion factor from kg/L to lb/gal
                 mcu += fermentable.amount * fermentable.color * 8.3454 / self.batch_size
         return 1.4922 * (mcu**0.6859)
+
+    def to_xml_element(self) -> Element:
+        """Serialize this recipe as a BeerXML ``<RECIPE>`` element."""
+        from pybeerxml.serializer import Serializer
+
+        return Serializer().recipe_to_xml_element(self)
+
+    def to_xml_string(self, encoding: str = "utf-8", xml_declaration: bool = True) -> str:
+        """Serialize this recipe as a complete BeerXML document string."""
+        from pybeerxml.serializer import Serializer
+
+        return Serializer().serialize([self], encoding=encoding, xml_declaration=xml_declaration)
+
+    def write_xml(self, path: str, encoding: str = "utf-8") -> None:
+        """Write this recipe as a complete BeerXML document to disk."""
+        from pybeerxml.serializer import Serializer
+
+        Serializer().write([self], path=path, encoding=encoding)
 
 
 class Recipes(BeerXmlModel, tag="RECIPES"):

--- a/pybeerxml/recipe.py
+++ b/pybeerxml/recipe.py
@@ -1,20 +1,22 @@
 import logging
-from typing import Any
 
+from pydantic_xml import element, wrapped
+
+from pybeerxml.base import BeerXmlModel, LenientFloat
 from pybeerxml.equipment import Equipment
 from pybeerxml.fermentable import Fermentable
 from pybeerxml.hop import Hop
 from pybeerxml.mash import Mash
 from pybeerxml.misc import Misc
 from pybeerxml.style import Style
-from pybeerxml.utils import cast_to_bool, gravity_to_plato
+from pybeerxml.utils import gravity_to_plato
 from pybeerxml.water import Water
 from pybeerxml.yeast import Yeast
 
 logger = logging.getLogger(__name__)
 
 
-class Recipe:
+class Recipe(BeerXmlModel, tag="RECIPE"):
     """A complete beer recipe parsed from a BeerXML document.
 
     Scalar fields (``name``, ``batch_size``, etc.) are populated directly from
@@ -23,8 +25,15 @@ class Recipe:
 
     - The plain property (e.g. ``recipe.og``) returns the stored XML value when
       present and falls back to the calculated value automatically.
+    - The trailing-underscore field (e.g. ``recipe.og_``) holds exactly the
+      value stored in the XML (``<OG>``), or ``None`` when absent. Only these
+      stored fields are written back during serialization.
     - The ``_calculated`` variant (e.g. ``recipe.og_calculated``) always
       computes from the ingredient list, regardless of what the XML says.
+
+    The previous private attribute names (``_og``, ``_fg``, ``_ibu``, ``_abv``,
+    ``_color``) remain available as compatibility aliases for ``og_``, ``fg_``,
+    ``ibu_``, ``abv_``, and ``color_``.
 
     All gravity values are also available in degrees Plato via ``og_plato``,
     ``og_calculated_plato``, ``fg_plato``, and ``fg_calculated_plato``.
@@ -55,61 +64,115 @@ class Recipe:
         Simcoe IPA 1.0756 64.3
     """
 
-    def __init__(self):
-        self.name: str | None = None
-        self.version: int | None = None
-        self.type: str | None = None
-        self.brewer: str | None = None
-        self.asst_brewer: str | None = None
-        self.batch_size: float | None = None
-        self.boil_time: float | None = None
-        self.boil_size: float | None = None
-        self.efficiency: float | None = None
-        self.notes: str | None = None
-        self.taste_notes: str | None = None
-        self.taste_rating: float | None = None
-        self.fermentation_stages: int | None = None
-        self.primary_age: float | None = None
-        self.primary_temp: float | None = None
-        self.secondary_age: float | None = None
-        self.secondary_temp: float | None = None
-        self.tertiary_age: float | None = None
-        self.tertiary_temp: float | None = None
-        self.carbonation: float | None = None
-        self.carbonation_temp: float | None = None
-        self.age: float | None = None
-        self.age_temp: float | None = None
-        self.date: str | None = None
-        self._forced_carbonation: bool | None = None
-        self.priming_sugar_name: str | None = None
-        self.priming_sugar_equiv: float | None = None
-        self.keg_priming_factor: float | None = None
+    name: str | None = element(tag="NAME", default=None)
+    version: int | None = element(tag="VERSION", default=None)
+    type: str | None = element(tag="TYPE", default=None)
+    brewer: str | None = element(tag="BREWER", default=None)
+    asst_brewer: str | None = element(tag="ASST_BREWER", default=None)
+    batch_size: float | None = element(tag="BATCH_SIZE", default=None)
+    boil_time: LenientFloat = element(tag="BOIL_TIME", default=None)
+    boil_size: LenientFloat = element(tag="BOIL_SIZE", default=None)
+    efficiency: LenientFloat = element(tag="EFFICIENCY", default=None)
+    notes: str | None = element(tag="NOTES", default=None)
+    taste_notes: str | None = element(tag="TASTE_NOTES", default=None)
+    taste_rating: LenientFloat = element(tag="TASTE_RATING", default=None)
+    fermentation_stages: int | None = element(tag="FERMENTATION_STAGES", default=None)
+    primary_age: LenientFloat = element(tag="PRIMARY_AGE", default=None)
+    primary_temp: LenientFloat = element(tag="PRIMARY_TEMP", default=None)
+    secondary_age: LenientFloat = element(tag="SECONDARY_AGE", default=None)
+    secondary_temp: LenientFloat = element(tag="SECONDARY_TEMP", default=None)
+    tertiary_age: LenientFloat = element(tag="TERTIARY_AGE", default=None)
+    tertiary_temp: LenientFloat = element(tag="TERTIARY_TEMP", default=None)
+    carbonation: LenientFloat = element(tag="CARBONATION", default=None)
+    carbonation_temp: LenientFloat = element(tag="CARBONATION_TEMP", default=None)
+    age: LenientFloat = element(tag="AGE", default=None)
+    age_temp: LenientFloat = element(tag="AGE_TEMP", default=None)
+    date: str | None = element(tag="DATE", default=None)
+    forced_carbonation: bool | None = element(tag="FORCED_CARBONATION", default=None)
+    priming_sugar_name: str | None = element(tag="PRIMING_SUGAR_NAME", default=None)
+    priming_sugar_equiv: LenientFloat = element(tag="PRIMING_SUGAR_EQUIV", default=None)
+    keg_priming_factor: LenientFloat = element(tag="KEG_PRIMING_FACTOR", default=None)
 
-        # Recipe extension fields
-        self.est_og: float | None = None
-        self.est_fg: float | None = None
-        self.est_color: float | None = None
-        self.ibu_method: str | None = None
-        self.est_abv: float | None = None
-        self.actual_efficiency: float | None = None
-        self.calories: str | None = None
-        self.carbonation_used: str | None = None
+    # Values stored in the XML; the matching public properties fall back to
+    # calculated values when these are None. Only these fields serialize.
+    og_: LenientFloat = element(tag="OG", default=None)
+    fg_: LenientFloat = element(tag="FG", default=None)
+    ibu_: LenientFloat = element(tag="IBU", default=None)
+    abv_: LenientFloat = element(tag="ABV", default=None)
+    color_: LenientFloat = element(tag="COLOR", default=None)
 
-        # Values from the recipe, which are calculated as a fallback
-        self._abv: float | None = None
-        self._og: float | None = None
-        self._fg: float | None = None
-        self._ibu: float | None = None
-        self._color: float | None = None
+    # Recipe extension fields
+    est_og: LenientFloat = element(tag="EST_OG", default=None)
+    est_fg: LenientFloat = element(tag="EST_FG", default=None)
+    est_color: LenientFloat = element(tag="EST_COLOR", default=None)
+    ibu_method: str | None = element(tag="IBU_METHOD", default=None)
+    est_abv: LenientFloat = element(tag="EST_ABV", default=None)
+    actual_efficiency: LenientFloat = element(tag="ACTUAL_EFFICIENCY", default=None)
+    calories: str | None = element(tag="CALORIES", default=None)
+    carbonation_used: str | None = element(tag="CARBONATION_USED", default=None)
 
-        self.style: Style | None = None
-        self.hops: list[Hop] = []
-        self.yeasts: list[Yeast] = []
-        self.fermentables: list[Fermentable] = []
-        self.miscs: list[Misc] = []
-        self.mash: Mash | None = None
-        self.waters: list[Water] = []
-        self.equipment: Equipment | None = None
+    style: Style | None = element(tag="STYLE", default=None)
+    equipment: Equipment | None = element(tag="EQUIPMENT", default=None)
+    mash: Mash | None = element(tag="MASH", default=None)
+    hops: list[Hop] = wrapped("HOPS", element(tag="HOP"), default_factory=list)
+    fermentables: list[Fermentable] = wrapped("FERMENTABLES", element(tag="FERMENTABLE"), default_factory=list)
+    yeasts: list[Yeast] = wrapped("YEASTS", element(tag="YEAST"), default_factory=list)
+    miscs: list[Misc] = wrapped("MISCS", element(tag="MISC"), default_factory=list)
+    waters: list[Water] = wrapped("WATERS", element(tag="WATER"), default_factory=list)
+
+    @property
+    def _og(self) -> float | str | None:
+        """Compatibility alias for `og_`."""
+        return self.og_
+
+    @_og.setter
+    def _og(self, value: float | str | None) -> None:
+        self.og_ = value
+
+    @property
+    def _fg(self) -> float | str | None:
+        """Compatibility alias for `fg_`."""
+        return self.fg_
+
+    @_fg.setter
+    def _fg(self, value: float | str | None) -> None:
+        self.fg_ = value
+
+    @property
+    def _ibu(self) -> float | str | None:
+        """Compatibility alias for `ibu_`."""
+        return self.ibu_
+
+    @_ibu.setter
+    def _ibu(self, value: float | str | None) -> None:
+        self.ibu_ = value
+
+    @property
+    def _abv(self) -> float | str | None:
+        """Compatibility alias for `abv_`."""
+        return self.abv_
+
+    @_abv.setter
+    def _abv(self, value: float | str | None) -> None:
+        self.abv_ = value
+
+    @property
+    def _color(self) -> float | str | None:
+        """Compatibility alias for `color_`."""
+        return self.color_
+
+    @_color.setter
+    def _color(self, value: float | str | None) -> None:
+        self.color_ = value
+
+    @property
+    def _forced_carbonation(self) -> bool | None:
+        """Compatibility alias for `forced_carbonation`."""
+        return self.forced_carbonation
+
+    @_forced_carbonation.setter
+    def _forced_carbonation(self, value: bool | None) -> None:
+        self.forced_carbonation = value
 
     @property
     def abv(self):
@@ -118,59 +181,39 @@ class Recipe:
         Returns the value stored in the XML when available, otherwise falls
         back to `abv_calculated`.
         """
-        if self._abv is not None:
-            return self._abv
+        if self.abv_ is not None:
+            return self.abv_
         logger.debug("The value for ABV has been calculated from OG and FG")
         return self.abv_calculated
 
     @abv.setter
     def abv(self, value):
-        self._abv = value
+        self.abv_ = value
 
     @property
     def abv_calculated(self):
         """ABV in percent, always computed from `og_calculated` and `fg_calculated`."""
         return ((1.05 * (self.og_calculated - self.fg_calculated)) / self.fg_calculated) / 0.79 * 100.0
 
-    @abv_calculated.setter
-    def abv_calculated(self, value):
-        pass
-
     @property
     def og_plato(self):
         """`og` expressed in degrees Plato."""
         return gravity_to_plato(self.og)
-
-    @og_plato.setter
-    def og_plato(self, value):
-        pass
 
     @property
     def og_calculated_plato(self):
         """`og_calculated` expressed in degrees Plato."""
         return gravity_to_plato(self.og_calculated)
 
-    @og_calculated_plato.setter
-    def og_calculated_plato(self, value):
-        pass
-
     @property
     def fg_plato(self):
         """`fg` expressed in degrees Plato."""
         return gravity_to_plato(self.fg)
 
-    @fg_plato.setter
-    def fg_plato(self, value):
-        pass
-
     @property
     def fg_calculated_plato(self):
         """`fg_calculated` expressed in degrees Plato."""
         return gravity_to_plato(self.fg_calculated)
-
-    @fg_calculated_plato.setter
-    def fg_calculated_plato(self, value):
-        pass
 
     @property
     def ibu(self):
@@ -179,14 +222,14 @@ class Recipe:
         Returns the value stored in the XML when available, otherwise falls
         back to `ibu_calculated`.
         """
-        if self._ibu is not None:
-            return self._ibu
+        if self.ibu_ is not None:
+            return self.ibu_
         logger.debug("The value for IBU has been calculated from the hop bill using Tinseth's formula")
         return self.ibu_calculated
 
     @ibu.setter
     def ibu(self, value):
-        self._ibu = value
+        self.ibu_ = value
 
     @property
     def ibu_calculated(self):
@@ -204,10 +247,6 @@ class Recipe:
                 _ibu += hop.bitterness(ibu_method, self.og_calculated, self.batch_size)
         return _ibu
 
-    @ibu_calculated.setter
-    def ibu_calculated(self, value):
-        pass
-
     @property
     def og(self):
         """Original gravity in SG.
@@ -215,14 +254,14 @@ class Recipe:
         Returns the value stored in the XML when available, otherwise falls
         back to `og_calculated`.
         """
-        if self._og is not None:
-            return self._og
+        if self.og_ is not None:
+            return self.og_
         logger.debug("The value for OG has been calculated from the mashing steps")
         return self.og_calculated
 
     @og.setter
     def og(self, value):
-        self._og = value
+        self.og_ = value
 
     @property
     def og_calculated(self):
@@ -255,10 +294,6 @@ class Recipe:
 
         return _og
 
-    @og_calculated.setter
-    def og_calculated(self, value):
-        pass
-
     @property
     def fg(self):
         """Final gravity in SG.
@@ -266,14 +301,14 @@ class Recipe:
         Returns the value stored in the XML when available, otherwise falls
         back to `fg_calculated`.
         """
-        if self._fg is not None:
-            return self._fg
+        if self.fg_ is not None:
+            return self.fg_
         logger.debug("The value for FG has been calculated from OG and yeast")
         return self.fg_calculated
 
     @fg.setter
     def fg(self, value):
-        self._fg = value
+        self.fg_ = value
 
     @property
     def fg_calculated(self):
@@ -290,10 +325,6 @@ class Recipe:
             attenuation = 75.0
         return self.og_calculated - ((self.og_calculated - 1.0) * attenuation / 100.0)
 
-    @fg_calculated.setter
-    def fg_calculated(self, value):
-        pass
-
     @property
     def color(self):
         """Beer colour in SRM.
@@ -301,14 +332,14 @@ class Recipe:
         Returns the value stored in the XML when available, otherwise falls
         back to `color_calculated`.
         """
-        if self._color is not None:
-            return self._color
+        if self.color_ is not None:
+            return self.color_
         logger.debug("The value for color has been calculated from fermentables using the Morey Equation")
         return self.color_calculated
 
     @color.setter
     def color(self, value):
-        self._color = value
+        self.color_ = value
 
     @property
     def color_calculated(self):
@@ -325,15 +356,15 @@ class Recipe:
                 mcu += fermentable.amount * fermentable.color * 8.3454 / self.batch_size
         return 1.4922 * (mcu**0.6859)
 
-    @color_calculated.setter
-    def color_calculated(self, value):
-        pass
 
-    @property
-    def forced_carbonation(self):
-        """Whether the beer is force-carbonated (``True``) or priming-sugar carbonated (``False``)."""
-        return self._forced_carbonation
+class Recipes(BeerXmlModel, tag="RECIPES"):
+    """Root element of a BeerXML document, containing one or more recipes.
 
-    @forced_carbonation.setter
-    def forced_carbonation(self, value: Any):
-        self._forced_carbonation = cast_to_bool(value)
+    Used internally by `pybeerxml.Parser` and `pybeerxml.Serializer` to read
+    and write the ``<RECIPES>`` document wrapper.
+
+    Attributes:
+        recipes: The recipes contained in the document.
+    """
+
+    recipes: list[Recipe] = element(tag="RECIPE", default_factory=list)

--- a/pybeerxml/serializer.py
+++ b/pybeerxml/serializer.py
@@ -1,48 +1,77 @@
 from __future__ import annotations
 
-import os
-import xml.dom.minidom
+from pathlib import Path
+from xml.etree import ElementTree
+from xml.etree.ElementTree import Element
 
 from pybeerxml.recipe import Recipe, Recipes
 
+REQUIRED_RECIPE_SECTIONS = ("HOPS", "FERMENTABLES", "MISCS", "YEASTS", "WATERS")
+
 
 class Serializer:
-    """Writes `Recipe` objects to BeerXML files or strings.
+    """Serialize `Recipe` objects into BeerXML.
 
-    Only values stored in the XML-backed fields are serialized — calculated
-    properties (``og_calculated``, ``og_plato``, etc.) are never written.
-    Fields that are ``None`` are omitted from the output, and boolean fields
-    are emitted as ``TRUE`` / ``FALSE`` per the BeerXML spec.
+    The API mirrors `Parser` on the write side:
 
-    Examples:
-        >>> from pybeerxml import Parser, Serializer
-        >>> recipes = Parser().parse("recipe.beerxml")
-        >>> Serializer().serialize(recipes, "copy.beerxml")
+    - `serialize()` returns a complete BeerXML document string
+    - `write()` writes a complete BeerXML document to disk
+    - `recipe_to_xml_element()` returns a single `<RECIPE>` element
+
+    BeerXML requires recipe record-set containers such as `HOPS` and
+    `FERMENTABLES`, so those sections are emitted even when empty.
     """
 
-    def serialize_to_string(self, recipes: Recipe | list[Recipe]) -> str:
-        """Serialize recipes to a BeerXML document string.
+    def recipe_to_xml_element(self, recipe: Recipe) -> Element:
+        """Serialize a single recipe as a BeerXML `<RECIPE>` element.
 
         Args:
-            recipes: A single `Recipe` or a list of `Recipe` objects.
+            recipe: The recipe to serialize.
 
         Returns:
-            A pretty-printed BeerXML document as a string, including the XML
-            declaration.
+            A single `<RECIPE>` XML element.
         """
-        if isinstance(recipes, Recipe):
-            recipes = [recipes]
-        document = Recipes(recipes=recipes)
-        raw_xml = document.to_xml(exclude_none=True)
-        return xml.dom.minidom.parseString(raw_xml).toprettyxml(indent="  ")
+        element = recipe.to_xml_tree(skip_empty=True)
+        _ensure_required_recipe_sections(element)
+        return element
 
-    def serialize(self, recipes: Recipe | list[Recipe], xml_file: str | os.PathLike) -> None:
-        """Serialize recipes to a BeerXML file on disk.
+    def serialize(self, recipes: list[Recipe], encoding: str = "utf-8", xml_declaration: bool = True) -> str:
+        """Serialize recipes into a complete BeerXML document string.
 
         Args:
-            recipes: A single `Recipe` or a list of `Recipe` objects.
-            xml_file: Destination path, e.g. ``"recipe.beerxml"``. Existing
-                files are overwritten.
+            recipes: Recipes to include in the document.
+            encoding: XML encoding to use for output.
+            xml_declaration: Whether to include the XML declaration.
+
+        Returns:
+            A BeerXML document as a string.
         """
-        with open(xml_file, "w", encoding="utf-8") as file:
-            file.write(self.serialize_to_string(recipes))
+        document = Recipes(recipes=recipes)
+        root = document.to_xml_tree(skip_empty=True)
+        for recipe_node in root.findall("RECIPE"):
+            _ensure_required_recipe_sections(recipe_node)
+        ElementTree.indent(root, space="  ")
+        xml = ElementTree.tostring(
+            root,
+            encoding=encoding if xml_declaration else "unicode",
+            xml_declaration=xml_declaration,
+        )
+        return xml if isinstance(xml, str) else xml.decode(encoding)
+
+    def write(self, recipes: list[Recipe], path: str | Path, encoding: str = "utf-8") -> None:
+        """Write recipes to a BeerXML file.
+
+        Args:
+            recipes: Recipes to serialize.
+            path: Destination file path.
+            encoding: XML encoding to use for output.
+        """
+        xml = self.serialize(recipes, encoding=encoding, xml_declaration=True)
+        Path(path).write_text(xml, encoding=encoding)
+
+
+def _ensure_required_recipe_sections(recipe_element: Element) -> None:
+    """Ensure BeerXML-required recipe container tags are present."""
+    for tag in REQUIRED_RECIPE_SECTIONS:
+        if recipe_element.find(tag) is None:
+            recipe_element.append(Element(tag))

--- a/pybeerxml/serializer.py
+++ b/pybeerxml/serializer.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+import os
+import xml.dom.minidom
+
+from pybeerxml.recipe import Recipe, Recipes
+
+
+class Serializer:
+    """Writes `Recipe` objects to BeerXML files or strings.
+
+    Only values stored in the XML-backed fields are serialized — calculated
+    properties (``og_calculated``, ``og_plato``, etc.) are never written.
+    Fields that are ``None`` are omitted from the output, and boolean fields
+    are emitted as ``TRUE`` / ``FALSE`` per the BeerXML spec.
+
+    Examples:
+        >>> from pybeerxml import Parser, Serializer
+        >>> recipes = Parser().parse("recipe.beerxml")
+        >>> Serializer().serialize(recipes, "copy.beerxml")
+    """
+
+    def serialize_to_string(self, recipes: Recipe | list[Recipe]) -> str:
+        """Serialize recipes to a BeerXML document string.
+
+        Args:
+            recipes: A single `Recipe` or a list of `Recipe` objects.
+
+        Returns:
+            A pretty-printed BeerXML document as a string, including the XML
+            declaration.
+        """
+        if isinstance(recipes, Recipe):
+            recipes = [recipes]
+        document = Recipes(recipes=recipes)
+        raw_xml = document.to_xml(exclude_none=True)
+        return xml.dom.minidom.parseString(raw_xml).toprettyxml(indent="  ")
+
+    def serialize(self, recipes: Recipe | list[Recipe], xml_file: str | os.PathLike) -> None:
+        """Serialize recipes to a BeerXML file on disk.
+
+        Args:
+            recipes: A single `Recipe` or a list of `Recipe` objects.
+            xml_file: Destination path, e.g. ``"recipe.beerxml"``. Existing
+                files are overwritten.
+        """
+        with open(xml_file, "w", encoding="utf-8") as file:
+            file.write(self.serialize_to_string(recipes))

--- a/pybeerxml/style.py
+++ b/pybeerxml/style.py
@@ -1,8 +1,9 @@
-from dataclasses import dataclass
+from pydantic_xml import element
+
+from pybeerxml.base import BeerXmlModel, LenientFloat
 
 
-@dataclass
-class Style:
+class Style(BeerXmlModel, tag="STYLE"):
     """Beer style guidelines from a BeerXML ``<STYLE>`` element.
 
     All ``_min`` / ``_max`` pairs define the acceptable range for that
@@ -31,23 +32,23 @@ class Style:
         notes: Free-text style notes.
     """
 
-    name: str | None = None
-    category: str | None = None
-    version: int | None = None
-    category_number: str | None = None
-    style_letter: str | None = None
-    style_guide: str | None = None
-    type: str | None = None
-    og_min: float | None = None
-    og_max: float | None = None
-    fg_min: float | None = None
-    fg_max: float | None = None
-    ibu_min: float | None = None
-    ibu_max: float | None = None
-    color_min: float | None = None
-    color_max: float | None = None
-    abv_min: float | None = None
-    abv_max: float | None = None
-    carb_min: float | None = None
-    carb_max: float | None = None
-    notes: str | None = None
+    name: str | None = element(tag="NAME", default=None)
+    category: str | None = element(tag="CATEGORY", default=None)
+    version: int | None = element(tag="VERSION", default=None)
+    category_number: str | None = element(tag="CATEGORY_NUMBER", default=None)
+    style_letter: str | None = element(tag="STYLE_LETTER", default=None)
+    style_guide: str | None = element(tag="STYLE_GUIDE", default=None)
+    type: str | None = element(tag="TYPE", default=None)
+    og_min: LenientFloat = element(tag="OG_MIN", default=None)
+    og_max: LenientFloat = element(tag="OG_MAX", default=None)
+    fg_min: LenientFloat = element(tag="FG_MIN", default=None)
+    fg_max: LenientFloat = element(tag="FG_MAX", default=None)
+    ibu_min: LenientFloat = element(tag="IBU_MIN", default=None)
+    ibu_max: LenientFloat = element(tag="IBU_MAX", default=None)
+    color_min: LenientFloat = element(tag="COLOR_MIN", default=None)
+    color_max: LenientFloat = element(tag="COLOR_MAX", default=None)
+    abv_min: LenientFloat = element(tag="ABV_MIN", default=None)
+    abv_max: LenientFloat = element(tag="ABV_MAX", default=None)
+    carb_min: LenientFloat = element(tag="CARB_MIN", default=None)
+    carb_max: LenientFloat = element(tag="CARB_MAX", default=None)
+    notes: str | None = element(tag="NOTES", default=None)

--- a/pybeerxml/water.py
+++ b/pybeerxml/water.py
@@ -1,8 +1,9 @@
-from dataclasses import dataclass
+from pydantic_xml import element
+
+from pybeerxml.base import BeerXmlModel, LenientFloat
 
 
-@dataclass
-class Water:
+class Water(BeerXmlModel, tag="WATER"):
     """Water chemistry profile from a BeerXML ``<WATER>`` element.
 
     All ion concentrations are in parts per million (ppm / mg/L).
@@ -20,15 +21,15 @@ class Water:
         notes: Free-text notes.
     """
 
-    name: str | None = None
-    version: int | None = None
-    amount: float | None = None
-    calcium: float | None = None
-    bicarbonate: float | None = None
-    sulfate: float | None = None
-    chloride: float | None = None
-    sodium: float | None = None
-    magnesium: float | None = None
-    ph: float | None = None
-    notes: str | None = None
-    volume: float | None = None
+    name: str | None = element(tag="NAME", default=None)
+    version: int | None = element(tag="VERSION", default=None)
+    amount: LenientFloat = element(tag="AMOUNT", default=None)
+    calcium: LenientFloat = element(tag="CALCIUM", default=None)
+    bicarbonate: LenientFloat = element(tag="BICARBONATE", default=None)
+    sulfate: LenientFloat = element(tag="SULFATE", default=None)
+    chloride: LenientFloat = element(tag="CHLORIDE", default=None)
+    sodium: LenientFloat = element(tag="SODIUM", default=None)
+    magnesium: LenientFloat = element(tag="MAGNESIUM", default=None)
+    ph: LenientFloat = element(tag="PH", default=None)
+    notes: str | None = element(tag="NOTES", default=None)
+    volume: LenientFloat = element(tag="VOLUME", default=None)

--- a/pybeerxml/yeast.py
+++ b/pybeerxml/yeast.py
@@ -1,11 +1,9 @@
-from dataclasses import dataclass, field
-from typing import Any
+from pydantic_xml import element
 
-from pybeerxml.utils import cast_to_bool
+from pybeerxml.base import BeerXmlModel, LenientFloat, LenientInt
 
 
-@dataclass
-class Yeast:
+class Yeast(BeerXmlModel, tag="YEAST"):
     """A yeast strain used in a recipe.
 
     Attributes:
@@ -14,49 +12,34 @@ class Yeast:
         form: Physical form — ``"Liquid"``, ``"Dry"``, ``"Slant"``, or ``"Culture"``.
         attenuation: Apparent attenuation percentage.
         laboratory: Producing laboratory (e.g. ``"Wyeast Labs"``).
-        product_id: Laboratory product identifier.
+        product_id: Laboratory product identifier. Numeric values are stored
+            as ``int``; alphanumeric identifiers (e.g. ``"WLP001"``) stay strings.
         flocculation: Flocculation level — ``"Low"``, ``"Medium"``, ``"High"``, or ``"Very High"``.
         amount: Volume (litres) or weight (kg) of yeast used.
+        amount_is_weight: ``True`` if ``amount`` is measured by weight (kg), ``False`` if by volume (L).
+        add_to_secondary: ``True`` if this yeast is pitched at the secondary fermentation stage.
         min_temperature: Minimum recommended fermentation temperature in °C.
         max_temperature: Maximum recommended fermentation temperature in °C.
         best_for: Beer styles best suited to this strain.
         notes: Free-text notes.
     """
 
-    name: str | None = None
-    version: int | None = None
-    type: str | None = None
-    form: str | None = None
-    attenuation: float | None = None
-    notes: str | None = None
-    laboratory: str | None = None
-    product_id: str | None = None
-    flocculation: str | None = None
-    amount: float | None = None
-    min_temperature: float | None = None
-    max_temperature: float | None = None
-    best_for: str | None = None
-    times_cultured: int | None = None
-    max_reuse: int | None = None
-    inventory: str | None = None
-    culture_date: str | None = None
-    _amount_is_weight: bool | None = field(default=None, init=False, repr=False)
-    _add_to_secondary: bool | None = field(default=None, init=False, repr=False)
-
-    @property
-    def amount_is_weight(self) -> bool | None:
-        """``True`` if ``amount`` is measured by weight (kg), ``False`` if by volume (L)."""
-        return self._amount_is_weight
-
-    @amount_is_weight.setter
-    def amount_is_weight(self, value: Any) -> None:
-        self._amount_is_weight = cast_to_bool(value)
-
-    @property
-    def add_to_secondary(self) -> bool | None:
-        """``True`` if this yeast is pitched at the secondary fermentation stage."""
-        return self._add_to_secondary
-
-    @add_to_secondary.setter
-    def add_to_secondary(self, value: Any) -> None:
-        self._add_to_secondary = cast_to_bool(value)
+    name: str | None = element(tag="NAME", default=None)
+    version: int | None = element(tag="VERSION", default=None)
+    type: str | None = element(tag="TYPE", default=None)
+    form: str | None = element(tag="FORM", default=None)
+    attenuation: float | None = element(tag="ATTENUATION", default=None)
+    notes: str | None = element(tag="NOTES", default=None)
+    laboratory: str | None = element(tag="LABORATORY", default=None)
+    product_id: LenientInt = element(tag="PRODUCT_ID", default=None)
+    flocculation: str | None = element(tag="FLOCCULATION", default=None)
+    amount: LenientFloat = element(tag="AMOUNT", default=None)
+    min_temperature: LenientFloat = element(tag="MIN_TEMPERATURE", default=None)
+    max_temperature: LenientFloat = element(tag="MAX_TEMPERATURE", default=None)
+    best_for: str | None = element(tag="BEST_FOR", default=None)
+    times_cultured: int | None = element(tag="TIMES_CULTURED", default=None)
+    max_reuse: int | None = element(tag="MAX_REUSE", default=None)
+    inventory: str | None = element(tag="INVENTORY", default=None)
+    culture_date: str | None = element(tag="CULTURE_DATE", default=None)
+    amount_is_weight: bool | None = element(tag="AMOUNT_IS_WEIGHT", default=None)
+    add_to_secondary: bool | None = element(tag="ADD_TO_SECONDARY", default=None)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,12 +1,16 @@
 [project]
 name = "pybeerxml"
-version = "2.2.0"
+version = "3.0.0"
 description = "A BeerXML implementation for Python"
 authors = [{ name = "Tom Herold", email = "heroldtom@gmail.com" }]
 license = { text = "MIT" }
 readme = "README.md"
 keywords = ["pybeerxml", "beerxml"]
 requires-python = ">=3.10"
+dependencies = [
+    "pydantic>=2.0",
+    "pydantic-xml>=2.0",
+]
 
 [project.urls]
 Repository = "https://github.com/hotzenklotz/pybeerxml/"

--- a/tests/test_parser.py
+++ b/tests/test_parser.py
@@ -1,6 +1,7 @@
 # -*- coding: utf-8 -*-
 import os
 from math import floor
+from xml.etree import ElementTree
 from xml.etree.ElementTree import Element, SubElement
 
 from pybeerxml.equipment import Equipment
@@ -299,20 +300,17 @@ def assert_coffee_stout_recipe(recipes):
     assert not recipe.yeasts[0].add_to_secondary
 
 
-def test_node_to_object():
-    "test XML node parsing to Python object"
+def test_hop_from_xml_element():
+    "test XML element parsing to a model"
 
-    node = Element("hop")
-    SubElement(node, "name").text = "Simcoe"
-    SubElement(node, "alpha").text = 13
-    SubElement(node, "amount").text = 0.5
-    SubElement(node, "use").text = "boil"
-    SubElement(node, "time").text = 30
+    node = Element("HOP")
+    SubElement(node, "NAME").text = "Simcoe"
+    SubElement(node, "ALPHA").text = "13"
+    SubElement(node, "AMOUNT").text = "0.5"
+    SubElement(node, "USE").text = "boil"
+    SubElement(node, "TIME").text = "30"
 
-    test_hop = Hop()
-
-    recipe_parser = Parser()
-    recipe_parser.nodes_to_object(node, test_hop)
+    test_hop = Hop.from_xml(ElementTree.tostring(node, encoding="unicode"))
 
     assert test_hop.name == "Simcoe"
     assert test_hop.alpha == 13

--- a/tests/test_serializer.py
+++ b/tests/test_serializer.py
@@ -42,8 +42,8 @@ def build_recipe():
     return recipe
 
 
-def test_serialize_to_string_structure():
-    xml = Serializer().serialize_to_string(build_recipe())
+def test_serialize_structure():
+    xml = Serializer().serialize([build_recipe()])
 
     assert xml.startswith("<?xml")
     assert "<RECIPES>" in xml
@@ -55,14 +55,14 @@ def test_serialize_to_string_structure():
 
 
 def test_serialize_stored_og():
-    xml = Serializer().serialize_to_string(build_recipe())
+    xml = Serializer().serialize([build_recipe()])
     assert "<OG>1.065</OG>" in xml
 
 
 def test_serialize_omits_unset_fields():
     recipe = Recipe()
     recipe.name = "Minimal"
-    xml = Serializer().serialize_to_string(recipe)
+    xml = Serializer().serialize([recipe])
 
     # no stored OG -> no OG element
     assert "<OG>" not in xml
@@ -71,38 +71,60 @@ def test_serialize_omits_unset_fields():
     # calculated values are never serialized
     assert "CALCULATED" not in xml
     assert "PLATO" not in xml
+    # BeerXML recipe record-set containers are required even when empty.
+    assert "<HOPS />" in xml or "<HOPS/>" in xml
+    assert "<FERMENTABLES />" in xml or "<FERMENTABLES/>" in xml
+    assert "<MISCS />" in xml or "<MISCS/>" in xml
+    assert "<YEASTS />" in xml or "<YEASTS/>" in xml
+    assert "<WATERS />" in xml or "<WATERS/>" in xml
 
 
 def test_serialize_booleans_uppercase():
-    xml = Serializer().serialize_to_string(build_recipe())
+    xml = Serializer().serialize([build_recipe()])
     assert "<FORCED_CARBONATION>TRUE</FORCED_CARBONATION>" in xml
     assert "<RECOMMEND_MASH>TRUE</RECOMMEND_MASH>" in xml
     assert "<AMOUNT_IS_WEIGHT>TRUE</AMOUNT_IS_WEIGHT>" in xml
 
 
 def test_serialize_yield_field():
-    xml = Serializer().serialize_to_string(build_recipe())
+    xml = Serializer().serialize([build_recipe()])
     assert "<YIELD>80.0</YIELD>" in xml
 
 
-def test_serialize_accepts_single_recipe():
-    xml = Serializer().serialize_to_string(build_recipe())
+def test_serialize_multiple_recipes():
+    xml = Serializer().serialize([build_recipe(), build_recipe()])
+    assert xml.count("<RECIPE>") == 2
+
+
+def test_recipe_to_xml_string_serializes_single_recipe():
+    xml = build_recipe().to_xml_string()
     assert xml.count("<RECIPE>") == 1
 
 
-def test_serialize_to_file(tmp_path):
+def test_write_to_file(tmp_path):
     path = tmp_path / "out.beerxml"
-    Serializer().serialize(build_recipe(), path)
+    Serializer().write([build_recipe()], path)
 
     recipes = Parser().parse(str(path))
     assert len(recipes) == 1
     assert recipes[0].name == "Test IPA"
 
 
+def test_recipe_serialization_helpers(tmp_path):
+    recipe = Parser().parse(RECIPE_PATH)[0]
+    path = tmp_path / "recipe.beerxml"
+
+    element = recipe.to_xml_element()
+    recipe.write_xml(str(path))
+
+    assert element.tag == "RECIPE"
+    assert Parser().parse(str(path))[0].name == recipe.name
+
+
 def test_round_trip_from_fixture():
     original = Parser().parse(RECIPE_PATH_3)[0]
 
-    xml = Serializer().serialize_to_string([original])
+    xml = Serializer().serialize([original])
     restored = Parser().parse_from_string(xml)[0]
 
     assert restored.name == original.name
@@ -145,7 +167,7 @@ def test_round_trip_from_fixture():
 def test_round_trip_preserves_calculated_values():
     original = Parser().parse(RECIPE_PATH)[0]
 
-    xml = Serializer().serialize_to_string([original])
+    xml = Serializer().serialize([original])
     restored = Parser().parse_from_string(xml)[0]
 
     assert round(restored.og_calculated, 4) == round(original.og_calculated, 4)
@@ -161,7 +183,7 @@ def test_compat_aliases_round_trip():
     assert recipe.og_ == 1.05
     assert recipe.og == 1.05
 
-    xml = Serializer().serialize_to_string(recipe)
+    xml = Serializer().serialize([recipe])
     assert "<OG>1.05</OG>" in xml
 
     restored = Parser().parse_from_string(xml)[0]

--- a/tests/test_serializer.py
+++ b/tests/test_serializer.py
@@ -1,0 +1,168 @@
+import os
+
+from pybeerxml import Parser, Serializer
+from pybeerxml.fermentable import Fermentable
+from pybeerxml.hop import Hop
+from pybeerxml.recipe import Recipe
+from pybeerxml.yeast import Yeast
+
+RECIPE_PATH = os.path.join(os.path.dirname(__file__), "Simcoe IPA.xml")
+RECIPE_PATH_3 = os.path.join(os.path.dirname(__file__), "CoffeeStout.xml")
+
+
+def build_recipe():
+    recipe = Recipe()
+    recipe.name = "Test IPA"
+    recipe.brewer = "Test Brewer"
+    recipe.batch_size = 20.0
+    recipe.og = 1.065
+    recipe.forced_carbonation = True
+
+    hop = Hop()
+    hop.name = "Simcoe"
+    hop.alpha = 13.0
+    hop.amount = 0.05
+    hop.use = "boil"
+    hop.time = 60
+    recipe.hops.append(hop)
+
+    fermentable = Fermentable()
+    fermentable.name = "Pale Malt"
+    fermentable.amount = 5.0
+    fermentable.yield_ = 80.0
+    fermentable.recommend_mash = True
+    recipe.fermentables.append(fermentable)
+
+    yeast = Yeast()
+    yeast.name = "US-05"
+    yeast.attenuation = 78.0
+    yeast.amount_is_weight = True
+    recipe.yeasts.append(yeast)
+
+    return recipe
+
+
+def test_serialize_to_string_structure():
+    xml = Serializer().serialize_to_string(build_recipe())
+
+    assert xml.startswith("<?xml")
+    assert "<RECIPES>" in xml
+    assert "<RECIPE>" in xml
+    assert "<NAME>Test IPA</NAME>" in xml
+    assert "<HOPS>" in xml
+    assert "<HOP>" in xml
+    assert "<NAME>Simcoe</NAME>" in xml
+
+
+def test_serialize_stored_og():
+    xml = Serializer().serialize_to_string(build_recipe())
+    assert "<OG>1.065</OG>" in xml
+
+
+def test_serialize_omits_unset_fields():
+    recipe = Recipe()
+    recipe.name = "Minimal"
+    xml = Serializer().serialize_to_string(recipe)
+
+    # no stored OG -> no OG element
+    assert "<OG>" not in xml
+    assert "<FG>" not in xml
+    assert "<IBU>" not in xml
+    # calculated values are never serialized
+    assert "CALCULATED" not in xml
+    assert "PLATO" not in xml
+
+
+def test_serialize_booleans_uppercase():
+    xml = Serializer().serialize_to_string(build_recipe())
+    assert "<FORCED_CARBONATION>TRUE</FORCED_CARBONATION>" in xml
+    assert "<RECOMMEND_MASH>TRUE</RECOMMEND_MASH>" in xml
+    assert "<AMOUNT_IS_WEIGHT>TRUE</AMOUNT_IS_WEIGHT>" in xml
+
+
+def test_serialize_yield_field():
+    xml = Serializer().serialize_to_string(build_recipe())
+    assert "<YIELD>80.0</YIELD>" in xml
+
+
+def test_serialize_accepts_single_recipe():
+    xml = Serializer().serialize_to_string(build_recipe())
+    assert xml.count("<RECIPE>") == 1
+
+
+def test_serialize_to_file(tmp_path):
+    path = tmp_path / "out.beerxml"
+    Serializer().serialize(build_recipe(), path)
+
+    recipes = Parser().parse(str(path))
+    assert len(recipes) == 1
+    assert recipes[0].name == "Test IPA"
+
+
+def test_round_trip_from_fixture():
+    original = Parser().parse(RECIPE_PATH_3)[0]
+
+    xml = Serializer().serialize_to_string([original])
+    restored = Parser().parse_from_string(xml)[0]
+
+    assert restored.name == original.name
+    assert restored.brewer == original.brewer
+    assert restored.batch_size == original.batch_size
+    assert restored.og_ == original.og_
+    assert restored.fg_ == original.fg_
+    assert restored.ibu_ == original.ibu_
+    assert restored.abv_ == original.abv_
+    assert restored.color_ == original.color_
+    assert restored.forced_carbonation == original.forced_carbonation
+    assert restored.est_color == original.est_color
+
+    assert len(restored.hops) == len(original.hops)
+    assert restored.hops[0].name == original.hops[0].name
+    assert restored.hops[0].alpha == original.hops[0].alpha
+
+    assert len(restored.fermentables) == len(original.fermentables)
+    assert restored.fermentables[0].name == original.fermentables[0].name
+    assert restored.fermentables[0].yield_ == original.fermentables[0].yield_
+    assert restored.fermentables[0].recommend_mash == original.fermentables[0].recommend_mash
+
+    assert len(restored.yeasts) == len(original.yeasts)
+    assert restored.yeasts[0].name == original.yeasts[0].name
+    assert restored.yeasts[0].product_id == original.yeasts[0].product_id
+    assert restored.yeasts[0].amount_is_weight == original.yeasts[0].amount_is_weight
+
+    assert len(restored.miscs) == len(original.miscs)
+    assert restored.miscs[0].name == original.miscs[0].name
+    assert restored.miscs[0].amount_is_weight == original.miscs[0].amount_is_weight
+
+    assert restored.style.name == original.style.name
+    assert restored.equipment.name == original.equipment.name
+    assert restored.equipment.calc_boil_volume == original.equipment.calc_boil_volume
+    assert restored.mash.name == original.mash.name
+    assert len(restored.mash.steps) == len(original.mash.steps)
+    assert restored.mash.steps[0].step_temp == original.mash.steps[0].step_temp
+
+
+def test_round_trip_preserves_calculated_values():
+    original = Parser().parse(RECIPE_PATH)[0]
+
+    xml = Serializer().serialize_to_string([original])
+    restored = Parser().parse_from_string(xml)[0]
+
+    assert round(restored.og_calculated, 4) == round(original.og_calculated, 4)
+    assert round(restored.fg_calculated, 4) == round(original.fg_calculated, 4)
+    assert round(restored.ibu_calculated, 2) == round(original.ibu_calculated, 2)
+    assert round(restored.abv_calculated, 2) == round(original.abv_calculated, 2)
+    assert round(restored.color_calculated, 2) == round(original.color_calculated, 2)
+
+
+def test_compat_aliases_round_trip():
+    recipe = Recipe()
+    recipe._og = 1.05
+    assert recipe.og_ == 1.05
+    assert recipe.og == 1.05
+
+    xml = Serializer().serialize_to_string(recipe)
+    assert "<OG>1.05</OG>" in xml
+
+    restored = Parser().parse_from_string(xml)[0]
+    assert restored._og == 1.05

--- a/uv.lock
+++ b/uv.lock
@@ -3,6 +3,15 @@ revision = 3
 requires-python = ">=3.10"
 
 [[package]]
+name = "annotated-types"
+version = "0.7.0"
+source = { registry = "https://pypi.org/simple" }
+sdist = { url = "https://files.pythonhosted.org/packages/ee/67/531ea369ba64dcff5ec9c3402f9f51bf748cec26dde048a2f973a4eea7f5/annotated_types-0.7.0.tar.gz", hash = "sha256:aff07c09a53a08bc8cfccb9c85b05f1aa9a2a6f23728d790723543408344ce89", size = 16081, upload-time = "2024-05-20T21:33:25.928Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/78/b6/6307fbef88d9b5ee7421e68d78a9f162e0da4900bc5f5793f6d3d0e34fb8/annotated_types-0.7.0-py3-none-any.whl", hash = "sha256:1f02e8b43a8fbbc3f3e0d4f0f4bfc8131bcb4eebe8849b8e5c773f3a1c582a53", size = 13643, upload-time = "2024-05-20T21:33:24.1Z" },
+]
+
+[[package]]
 name = "click"
 version = "8.3.1"
 source = { registry = "https://pypi.org/simple" }
@@ -311,8 +320,12 @@ wheels = [
 
 [[package]]
 name = "pybeerxml"
-version = "2.2.0"
+version = "3.0.0"
 source = { editable = "." }
+dependencies = [
+    { name = "pydantic" },
+    { name = "pydantic-xml" },
+]
 
 [package.dev-dependencies]
 dev = [
@@ -324,6 +337,10 @@ dev = [
 ]
 
 [package.metadata]
+requires-dist = [
+    { name = "pydantic", specifier = ">=2.0" },
+    { name = "pydantic-xml", specifier = ">=2.0" },
+]
 
 [package.metadata.requires-dev]
 dev = [
@@ -332,6 +349,150 @@ dev = [
     { name = "ruff", specifier = ">=0.9" },
     { name = "ty", specifier = ">=0.0.1" },
     { name = "zensical" },
+]
+
+[[package]]
+name = "pydantic"
+version = "2.13.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "annotated-types" },
+    { name = "pydantic-core" },
+    { name = "typing-extensions" },
+    { name = "typing-inspection" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/18/a5/b60d21ac674192f8ab0ba4e9fd860690f9b4a6e51ca5df118733b487d8d6/pydantic-2.13.4.tar.gz", hash = "sha256:c40756b57adaa8b1efeeced5c196f3f3b7c435f90e84ea7f443901bec8099ef6", size = 844775, upload-time = "2026-05-06T13:43:05.343Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/fd/7b/122376b1fd3c62c1ed9dc80c931ace4844b3c55407b6fb2d199377c9736f/pydantic-2.13.4-py3-none-any.whl", hash = "sha256:45a282cde31d808236fd7ea9d919b128653c8b38b393d1c4ab335c62924d9aba", size = 472262, upload-time = "2026-05-06T13:43:02.641Z" },
+]
+
+[[package]]
+name = "pydantic-core"
+version = "2.46.4"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/9d/56/921726b776ace8d8f5db44c4ef961006580d91dc52b803c489fafd1aa249/pydantic_core-2.46.4.tar.gz", hash = "sha256:62f875393d7f270851f20523dd2e29f082bcc82292d66db2b64ea71f64b6e1c1", size = 471464, upload-time = "2026-05-06T13:37:06.98Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/e7/08/f1ba952f1c8ae5581c70fa9c6da89f247b83e3dd8c09c035d5d7931fc23d/pydantic_core-2.46.4-cp310-cp310-macosx_10_12_x86_64.whl", hash = "sha256:a396dcc17e5a0b164dbe026896245a4fa9ff402edca1dff0be3d53a517f74de4", size = 2113146, upload-time = "2026-05-06T13:37:36.537Z" },
+    { url = "https://files.pythonhosted.org/packages/56/c6/65f646c7ff09bd257f660434adb45c4dfcbbcebcc030562fecf6f5bf887d/pydantic_core-2.46.4-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:da4b951fe36dc7c3a1ccb4e3cd1747c3542b8c9ceede8fc86cae054e764485f5", size = 1949769, upload-time = "2026-05-06T13:37:46.365Z" },
+    { url = "https://files.pythonhosted.org/packages/64/ba/bfb1d928fd5b49e1258935ff104ae356e9fd89384a55bf9f847e9193ad40/pydantic_core-2.46.4-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:bb63e0198ca18aad131c089b9204c23079c3afa95487e561f4c522d519e55aba", size = 1974958, upload-time = "2026-05-06T13:37:28.611Z" },
+    { url = "https://files.pythonhosted.org/packages/4e/74/76223bfb117b64af743c9b6670d1364516f5c0604f96b48f3272f6af6cc6/pydantic_core-2.46.4-cp310-cp310-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:f47286a97f0bc9b8859519809077b91b2cefe4ae47fcbf5e466a009c1c5d742b", size = 2042118, upload-time = "2026-05-06T13:36:55.216Z" },
+    { url = "https://files.pythonhosted.org/packages/cb/7b/848732968bc8f48f3187542f08358b9d842db564147b256669426ebb1652/pydantic_core-2.46.4-cp310-cp310-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:905a0ed8ea6f2d61c1738835f99b699348d7857379083e5fc497fa0c967a407c", size = 2222876, upload-time = "2026-05-06T13:38:25.455Z" },
+    { url = "https://files.pythonhosted.org/packages/b5/2f/e90b63ee2e14bd8d3db8f705a6d75d64e6ee1b7c2c8833747ce706e1e0ce/pydantic_core-2.46.4-cp310-cp310-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:ea793e075b70290d89d8142074262885d3f7da19634845135751bd6344f73b50", size = 2286703, upload-time = "2026-05-06T13:37:53.304Z" },
+    { url = "https://files.pythonhosted.org/packages/ba/1e/acc4d70f88a0a277e4a1fa77ebb985ceabaf900430f875bf9338e11c9420/pydantic_core-2.46.4-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:395aebd9183f9d112f569aeb5b2214d1a10a33bec8456447f7fbdfa51d38d4cd", size = 2092042, upload-time = "2026-05-06T13:38:46.981Z" },
+    { url = "https://files.pythonhosted.org/packages/a9/da/0a422b57bf8504102bf3c4ccea9c41bab5a5cee6a54650acf8faf67f5a24/pydantic_core-2.46.4-cp310-cp310-manylinux_2_31_riscv64.whl", hash = "sha256:b078afbc25f3a1436c7a1d2cd3e322497ee99615ba97c563566fdf46aff1ee01", size = 2117231, upload-time = "2026-05-06T13:39:23.146Z" },
+    { url = "https://files.pythonhosted.org/packages/bd/2a/2ac13c3af305843e23c5078c53d135656b3f05a2fd78cb7bbbb12e97b473/pydantic_core-2.46.4-cp310-cp310-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:f747929cf940cddb5b3668a390056ddd5ba2e5010615ea2dcf4f9c4f3ab8791d", size = 2168388, upload-time = "2026-05-06T13:40:08.06Z" },
+    { url = "https://files.pythonhosted.org/packages/72/04/2beacf7e1607e93eefe4aed1b4709f079b905fb77530179d4f7c71745f22/pydantic_core-2.46.4-cp310-cp310-musllinux_1_1_aarch64.whl", hash = "sha256:daa27d92c36f24388fe3ad306b174781c747627f134452e4f128ea00ce1fe8c4", size = 2184769, upload-time = "2026-05-06T13:38:13.901Z" },
+    { url = "https://files.pythonhosted.org/packages/9e/29/d2b9fd9f539133548eaf622c06a4ce176cb46ac59f32d0359c4abc0de047/pydantic_core-2.46.4-cp310-cp310-musllinux_1_1_armv7l.whl", hash = "sha256:19e51f073cd3df251856a8a4189fbdf1de4012c3ebacfb1884f94f1eb406079f", size = 2319312, upload-time = "2026-05-06T13:39:08.24Z" },
+    { url = "https://files.pythonhosted.org/packages/7c/af/0f7a5b85fec6075bea96e3ef9187de38fccced0de92c1e7feda8d5cc7bb9/pydantic_core-2.46.4-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:c1747f85cee84c26985853c6f3d9bd3e75da5212912443fa111c113b9c246f39", size = 2361817, upload-time = "2026-05-06T13:38:43.2Z" },
+    { url = "https://files.pythonhosted.org/packages/25/a4/73363fec545fd3ec025490bdda2743c56d0dd5b6266b1a53bbe9e4265375/pydantic_core-2.46.4-cp310-cp310-win32.whl", hash = "sha256:2f84c03c8607173d16b5a854ec68a2f9079ae03237a54fb506d13af47e1d018d", size = 1987085, upload-time = "2026-05-06T13:39:25.497Z" },
+    { url = "https://files.pythonhosted.org/packages/01/aa/62f082da2c91fac1c234bc9ee0066257ce83f0604abd72e4c9d5991f2d84/pydantic_core-2.46.4-cp310-cp310-win_amd64.whl", hash = "sha256:8358a950c8909158e3df31538a7e4edc2d7265a7c54b47f0864d9e5bae9dcebf", size = 2074311, upload-time = "2026-05-06T13:39:59.922Z" },
+    { url = "https://files.pythonhosted.org/packages/5c/fa/6d7708d2cfc1a832acb6aeb0cd16e801902df8a0f583bb3b4b527fde022e/pydantic_core-2.46.4-cp311-cp311-macosx_10_12_x86_64.whl", hash = "sha256:0e96592440881c74a213e5ad528e2b24d3d4f940de2766bed9010ab1d9e51594", size = 2111872, upload-time = "2026-05-06T13:40:27.596Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/6f/aa064a3e74b5745afbdf250594f38e7ead05e2d651bcb35994b9417a0d4d/pydantic_core-2.46.4-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:e0d65b8c354be7fb5f720c3caa8bc940bc2d20ce749c8e06135f07f8ed95dd7c", size = 1948255, upload-time = "2026-05-06T13:39:12.574Z" },
+    { url = "https://files.pythonhosted.org/packages/43/3a/41114a9f7569b84b4d84e7a018c57c56347dac30c0d4a872946ec4e36c46/pydantic_core-2.46.4-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:7bfb192b3f4b9e8a89b6277b6ce787564f62cfd272055f6e685726b111dc7826", size = 1972827, upload-time = "2026-05-06T13:38:19.841Z" },
+    { url = "https://files.pythonhosted.org/packages/ef/25/1ab42e8048fe551934d9884e8d64daa7e990ad386f310a15981aeb6a5b08/pydantic_core-2.46.4-cp311-cp311-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:9037063db01f09b09e237c282b6792bd4da634b5402c4e7f0c61effed7701a04", size = 2041051, upload-time = "2026-05-06T13:38:10.447Z" },
+    { url = "https://files.pythonhosted.org/packages/94/c2/1a934597ddf08da410385b3b7aae91956a5a76c635effef456074fad7e88/pydantic_core-2.46.4-cp311-cp311-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:fc010ab034c8c7452522748bf937df58020d256ccae0874463d1f4d01758af8e", size = 2221314, upload-time = "2026-05-06T13:40:13.089Z" },
+    { url = "https://files.pythonhosted.org/packages/02/6d/9e8ad178c9c4df27ad3c8f25d1fe2a7ab0d2ba0559fad4aee5d3d1f16771/pydantic_core-2.46.4-cp311-cp311-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:8c5dac79fa1614d1e06ca695109c6105923bd9c7d1d6c918d4e637b7e6b32fd3", size = 2285146, upload-time = "2026-05-06T13:38:59.224Z" },
+    { url = "https://files.pythonhosted.org/packages/80/50/540cd3aeefc041beb111125c4bff779831a2111fc6b15a9138cda277d32c/pydantic_core-2.46.4-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f9fa868638bf362d3d138ea55829cefb3d5f4b0d7f142234382a15e2485dbec4", size = 2089685, upload-time = "2026-05-06T13:38:17.762Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/a4/b440ad35f05f6a38f89fa0f149accb3f0e02be94ca5e15f3c449a61b4bc9/pydantic_core-2.46.4-cp311-cp311-manylinux_2_31_riscv64.whl", hash = "sha256:17299feefe090f2caa5b8e37222bb5f663e4935a8bfa6931d4102e5df1a9f398", size = 2115420, upload-time = "2026-05-06T13:37:58.195Z" },
+    { url = "https://files.pythonhosted.org/packages/99/61/de4f55db8dfd57bfdfa9a12ec90fe1b57c4f41062f7ca86f08586b3e0ac0/pydantic_core-2.46.4-cp311-cp311-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:4c63ebc82684aa89d9a3bcbd13d515b3be44250dc68dd3bd81526c1cb31286c3", size = 2165122, upload-time = "2026-05-06T13:37:01.167Z" },
+    { url = "https://files.pythonhosted.org/packages/f7/52/7c529d7bdb2d1068bd52f51fe32572c8301f9a4febf1948f10639f1436f5/pydantic_core-2.46.4-cp311-cp311-musllinux_1_1_aarch64.whl", hash = "sha256:aaa2a54443eff1950ba5ddc6b6ccda0d9c84a364276a62f969bdf2a390650848", size = 2182573, upload-time = "2026-05-06T13:38:45.04Z" },
+    { url = "https://files.pythonhosted.org/packages/37/b3/7c40325848ba78247f2812dcf9c7274e38cd801820ca6dd9fe63bcfb0eb4/pydantic_core-2.46.4-cp311-cp311-musllinux_1_1_armv7l.whl", hash = "sha256:18e5ceec2ab67e6d5f1a9085e5a24c9c4e2ac4545730bfe668680bca05e555f3", size = 2317139, upload-time = "2026-05-06T13:37:15.539Z" },
+    { url = "https://files.pythonhosted.org/packages/d9/37/f913f81a657c865b75da6c0dbed79876073c2a43b5bd9edbe8da785e4d49/pydantic_core-2.46.4-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:a0f62d0a58f4e7da165457e995725421e0064f2255d8eccebc49f41bbc23b109", size = 2360433, upload-time = "2026-05-06T13:37:30.099Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/67/6acaa1be2567f9256b056d8477158cac7240813956ce86e49deae8e173b4/pydantic_core-2.46.4-cp311-cp311-win32.whl", hash = "sha256:041bde0a48fd37cf71cab1c9d56d3e8625a3793fef1f7dd232b3ff37e978ecda", size = 1985513, upload-time = "2026-05-06T13:38:15.669Z" },
+    { url = "https://files.pythonhosted.org/packages/aa/e6/c505f83dfeda9a2e5c995cfd872949e4d05e12f7feb3dca72f633daefa94/pydantic_core-2.46.4-cp311-cp311-win_amd64.whl", hash = "sha256:6f2eeda33a839975441c86a4119e1383c50b47faf0cbb5176985565c6bb02c33", size = 2071114, upload-time = "2026-05-06T13:40:35.416Z" },
+    { url = "https://files.pythonhosted.org/packages/0f/da/7a263a96d965d9d0df5e8de8a475f33495451117035b09acb110288c381f/pydantic_core-2.46.4-cp311-cp311-win_arm64.whl", hash = "sha256:14f4c5d6db102bd796a627bbb3a17b4cf4574b9ae861d8b7c9a9661c6dd3362d", size = 2044298, upload-time = "2026-05-06T13:38:29.754Z" },
+    { url = "https://files.pythonhosted.org/packages/ce/8c/af022f0af448d7747c5154288d46b5f2bc5f17366eaa0e23e9aa04d59f3b/pydantic_core-2.46.4-cp312-cp312-macosx_10_12_x86_64.whl", hash = "sha256:3245406455a5d98187ec35530fd772b1d799b26667980872c8d4614991e2c4a2", size = 2106158, upload-time = "2026-05-06T13:38:57.215Z" },
+    { url = "https://files.pythonhosted.org/packages/19/95/6195171e385007300f0f5574592e467c568becce2d937a0b6804f218bc49/pydantic_core-2.46.4-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:962ccbab7b642487b1d8b7df90ef677e03134cf1fd8880bf698649b22a69371f", size = 1951724, upload-time = "2026-05-06T13:37:02.697Z" },
+    { url = "https://files.pythonhosted.org/packages/8e/bc/f47d1ff9cbb1620e1b5b697eef06010035735f07820180e74178226b27b3/pydantic_core-2.46.4-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8233f2947cf85404441fd7e0085f53b10c93e0ee78611099b5c7237e36aacbf7", size = 1975742, upload-time = "2026-05-06T13:37:09.448Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/11/9b9a5b0306345664a2da6410877af6e8082481b5884b3ddd78d47c6013ce/pydantic_core-2.46.4-cp312-cp312-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:3a233125ac121aa3ffba9a2b59edfc4a985a76092dc8279586ab4b71390875e7", size = 2052418, upload-time = "2026-05-06T13:37:38.234Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/b7/a65fec226f5d78fc39f4a13c4cc0c768c22b113438f60c14adc9d2865038/pydantic_core-2.46.4-cp312-cp312-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:5b712b53160b79a5850310b912a5ef8e57e56947c8ad690c227f5c9d7e561712", size = 2232274, upload-time = "2026-05-06T13:38:27.753Z" },
+    { url = "https://files.pythonhosted.org/packages/68/f0/92039db98b907ef49269a8271f67db9cb78ae2fc68062ef7e4e77adb5f61/pydantic_core-2.46.4-cp312-cp312-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:9401557acd873c3a7f3eb9383edef8ac4968f9510e340f4808d427e75667e7b4", size = 2309940, upload-time = "2026-05-06T13:38:05.353Z" },
+    { url = "https://files.pythonhosted.org/packages/5f/97/2aab507d3d00ca626e8e57c1eac6a79e4e5fbcc63eb99733ff55d1717f65/pydantic_core-2.46.4-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:926c9541b14b12b1681dca8a0b75feb510b06c6341b70a8e500c2fdcff837cce", size = 2094516, upload-time = "2026-05-06T13:39:10.577Z" },
+    { url = "https://files.pythonhosted.org/packages/22/37/a8aca44d40d737dde2bc05b3c6c07dff0de07ce6f82e9f3167aeaf4d5dea/pydantic_core-2.46.4-cp312-cp312-manylinux_2_31_riscv64.whl", hash = "sha256:56cb4851bcaf3d117eddcef4fe66afd750a50274b0da8e22be256d10e5611987", size = 2136854, upload-time = "2026-05-06T13:40:22.59Z" },
+    { url = "https://files.pythonhosted.org/packages/24/99/fcef1b79238c06a8cbec70819ac722ba76e02bc8ada9b0fd66eba40da01b/pydantic_core-2.46.4-cp312-cp312-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:c68fcd102d71ea85c5b2dfac3f4f8476eff42a9e078fd5faefff6d145063536b", size = 2180306, upload-time = "2026-05-06T13:40:10.666Z" },
+    { url = "https://files.pythonhosted.org/packages/ae/6c/fc44000918855b42779d007ae63b0532794739027b2f417321cddbc44f6a/pydantic_core-2.46.4-cp312-cp312-musllinux_1_1_aarch64.whl", hash = "sha256:b2f69dec1725e79a012d920df1707de5caf7ed5e08f3be4435e25803efc47458", size = 2190044, upload-time = "2026-05-06T13:40:43.231Z" },
+    { url = "https://files.pythonhosted.org/packages/6b/65/d9cadc9f1920d7a127ad2edba16c1db7916e59719285cd6c94600b0080ba/pydantic_core-2.46.4-cp312-cp312-musllinux_1_1_armv7l.whl", hash = "sha256:8d0820e8192167f80d88d64038e609c31452eeca865b4e1d9950a27a4609b00b", size = 2329133, upload-time = "2026-05-06T13:39:57.365Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/cf/c873d91679f3a30bcf5e7ac280ce5573483e72295307685120d0d5ad3416/pydantic_core-2.46.4-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:fbdb89b3e1c94a30cc5edfce477c6e6a5dc4d8f84665b455c27582f211a1c72c", size = 2374464, upload-time = "2026-05-06T13:38:06.976Z" },
+    { url = "https://files.pythonhosted.org/packages/47/bd/6f2fc8188f31bf10590f1e98e7b306336161fac930a8c514cd7bd828c7dc/pydantic_core-2.46.4-cp312-cp312-win32.whl", hash = "sha256:9aa768456404a8bf48a4406685ac2bec8e72b62c69313734fa3b73cf33b3a894", size = 1974823, upload-time = "2026-05-06T13:40:47.985Z" },
+    { url = "https://files.pythonhosted.org/packages/40/8c/985c1d41ea1107c2534abd9870e4ed5c8e7669b5c308297835c001e7a1c4/pydantic_core-2.46.4-cp312-cp312-win_amd64.whl", hash = "sha256:e9c26f834c65f5752f3f06cb08cb86a913ceb7274d0db6e267808a708b46bc89", size = 2072919, upload-time = "2026-05-06T13:39:21.153Z" },
+    { url = "https://files.pythonhosted.org/packages/c4/ba/f463d006e0c47373ca7ec5e1a261c59dc01ef4d62b2657af925fb0deee3a/pydantic_core-2.46.4-cp312-cp312-win_arm64.whl", hash = "sha256:4fc73cb559bdb54b1134a706a2802a4cddd27a0633f5abb7e53056268751ac6a", size = 2027604, upload-time = "2026-05-06T13:39:03.753Z" },
+    { url = "https://files.pythonhosted.org/packages/51/a2/5d30b469c5267a17b39dec53208222f76a8d351dfac4af661888c5aee77d/pydantic_core-2.46.4-cp313-cp313-macosx_10_12_x86_64.whl", hash = "sha256:5d5902252db0d3cedf8d4a1bc68f70eeb430f7e4c7104c8c476753519b423008", size = 2106306, upload-time = "2026-05-06T13:37:48.029Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/81/4fa520eaffa8bd7d1525e644cd6d39e7d60b1592bc5b516693c7340b50f1/pydantic_core-2.46.4-cp313-cp313-macosx_11_0_arm64.whl", hash = "sha256:c94f0688e7b8d0a67abf40e57a7eaaecd17cc9586706a31b76c031f63df052b4", size = 1951906, upload-time = "2026-05-06T13:37:17.012Z" },
+    { url = "https://files.pythonhosted.org/packages/03/d5/fd02da45b659668b05923b17ba3a0100a0a3d5541e3bd8fcc4ecb711309e/pydantic_core-2.46.4-cp313-cp313-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:f027324c56cd5406ca49c124b0db10e56c69064fec039acc571c29020cc87c76", size = 1976802, upload-time = "2026-05-06T13:37:35.113Z" },
+    { url = "https://files.pythonhosted.org/packages/21/f2/95727e1368be3d3ed485eaab7adbd7dda408f33f7a36e8b48e0144002b91/pydantic_core-2.46.4-cp313-cp313-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:e739fee756ba1010f8bcccb534252e85a35fe45ae92c295a06059ce58b74ccd3", size = 2052446, upload-time = "2026-05-06T13:37:12.313Z" },
+    { url = "https://files.pythonhosted.org/packages/9c/86/5d99feea3f77c7234b8718075b23db11532773c1a0dbd9b9490215dc2eeb/pydantic_core-2.46.4-cp313-cp313-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:9d56801be94b86a9da183e5f3766e6310752b99ff647e38b09a9500d88e46e76", size = 2232757, upload-time = "2026-05-06T13:39:01.149Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/3a/508ac615935ef7588cf6d9e9b91309fdc2da751af865e02a9098de88258c/pydantic_core-2.46.4-cp313-cp313-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:2412e734dcb48da14d4e4006b82b46b74f2518b8a26ee7e58c6844a6cd6d03c4", size = 2309275, upload-time = "2026-05-06T13:37:41.406Z" },
+    { url = "https://files.pythonhosted.org/packages/07/f8/41db9de19d7987d6b04715a02b3b40aea467000275d9d758ffaa31af7d50/pydantic_core-2.46.4-cp313-cp313-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9551187363ffc0de2a00b2e47c25aeaeb1020b69b668762966df15fc5659dd5a", size = 2094467, upload-time = "2026-05-06T13:39:18.847Z" },
+    { url = "https://files.pythonhosted.org/packages/2c/e2/f35033184cb11d0052daf4416e8e10a502ea2ac006fc4f459aee872727d1/pydantic_core-2.46.4-cp313-cp313-manylinux_2_31_riscv64.whl", hash = "sha256:0186750b482eefa11d7f435892b09c5c606193ef3375bcf94aa00ae6bfb66262", size = 2134417, upload-time = "2026-05-06T13:40:17.944Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/7b/6ceeb1cc90e193862f444ebe373d8fdf613f0a82572dde03fb10734c6c71/pydantic_core-2.46.4-cp313-cp313-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:5855698a4856556d86e8e6cd8434bc3ac0314ee8e12089ae0e143f64c6256e4e", size = 2179782, upload-time = "2026-05-06T13:40:32.618Z" },
+    { url = "https://files.pythonhosted.org/packages/5a/f2/c8d7773ede6af08036423a00ae0ceffce266c3c52a096c435d68c896083f/pydantic_core-2.46.4-cp313-cp313-musllinux_1_1_aarch64.whl", hash = "sha256:cbaf13819775b7f769bf4a1f066cb6df7a28d4480081a589828ef190226881cd", size = 2188782, upload-time = "2026-05-06T13:36:51.018Z" },
+    { url = "https://files.pythonhosted.org/packages/59/31/0c864784e31f09f05cdd87606f08923b9c9e7f6e51dd27f20f62f975ce9f/pydantic_core-2.46.4-cp313-cp313-musllinux_1_1_armv7l.whl", hash = "sha256:633147d34cf4550417f12e2b1a0383973bdf5cdfde212cb09e9a581cf10820be", size = 2328334, upload-time = "2026-05-06T13:40:37.764Z" },
+    { url = "https://files.pythonhosted.org/packages/c2/eb/4f6c8a41efa30baa755590f4141abf3a8c370fab610915733e74134a7270/pydantic_core-2.46.4-cp313-cp313-musllinux_1_1_x86_64.whl", hash = "sha256:82cf5301172168103724d49a1444d3378cb20cdee30b116a1bd6031236298a5d", size = 2372986, upload-time = "2026-05-06T13:39:34.152Z" },
+    { url = "https://files.pythonhosted.org/packages/5b/24/b375a480d53113860c299764bfe9f349a3dc9108b3adc0d7f0d786492ebf/pydantic_core-2.46.4-cp313-cp313-win32.whl", hash = "sha256:9fa8ae11da9e2b3126c6426f147e0fba88d96d65921799bb30c6abd1cb2c97fb", size = 1973693, upload-time = "2026-05-06T13:37:55.072Z" },
+    { url = "https://files.pythonhosted.org/packages/7e/e8/cff247591966f2d22ec8c003cd7587e27b7ba7b81ab2fb888e3ab75dc285/pydantic_core-2.46.4-cp313-cp313-win_amd64.whl", hash = "sha256:6b3ace8194b0e5204818c92802dcdca7fc6d88aabbb799d7c795540d9cd6d292", size = 2071819, upload-time = "2026-05-06T13:38:49.139Z" },
+    { url = "https://files.pythonhosted.org/packages/c6/1a/f4aee670d5670e9e148e0c82c7db98d780be566c6e6a97ee8035528ca0b3/pydantic_core-2.46.4-cp313-cp313-win_arm64.whl", hash = "sha256:184c081504d17f1c1066e430e117142b2c77d9448a97f7b65c6ac9fd9aee238d", size = 2027411, upload-time = "2026-05-06T13:40:45.796Z" },
+    { url = "https://files.pythonhosted.org/packages/8d/74/228a26ddad29c6672b805d9fd78e8d251cd04004fa7eed0e622096cd0250/pydantic_core-2.46.4-cp314-cp314-macosx_10_12_x86_64.whl", hash = "sha256:428e04521a40150c85216fc8b85e8d39fece235a9cf5e383761238c7fa9b96fb", size = 2102079, upload-time = "2026-05-06T13:38:41.019Z" },
+    { url = "https://files.pythonhosted.org/packages/ad/1f/8970b150a4b4365623ae00fc88603491f763c627311ae8031e3111356d6e/pydantic_core-2.46.4-cp314-cp314-macosx_11_0_arm64.whl", hash = "sha256:23ace664830ee0bfe014a0c7bc248b1f7f25ed7ad103852c317624a1083af462", size = 1952179, upload-time = "2026-05-06T13:36:59.812Z" },
+    { url = "https://files.pythonhosted.org/packages/95/30/5211a831ae054928054b2f79731661087a2bc5c01e825c672b3a4a8f1b3e/pydantic_core-2.46.4-cp314-cp314-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ce5c1d2a8b27468f433ca974829c44060b8097eedc39933e3c206a90ee49c4a9", size = 1978926, upload-time = "2026-05-06T13:37:39.933Z" },
+    { url = "https://files.pythonhosted.org/packages/57/e9/689668733b1eb67adeef047db3c2e8788fcf65a7fd9c9e2b46b7744fe245/pydantic_core-2.46.4-cp314-cp314-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:7283d57845ecf5a163403eb0702dfc220cc4fbdd18919cb5ccea4f95ee1cdab4", size = 2046785, upload-time = "2026-05-06T13:38:01.995Z" },
+    { url = "https://files.pythonhosted.org/packages/60/d9/6715260422ff50a2109878fd24d948a6c3446bb2664f34ee78cd972b3acd/pydantic_core-2.46.4-cp314-cp314-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:8daafc69c93ee8a0204506a3b6b30f586ef54028f52aeeeb5c4cfc5184fd5914", size = 2228733, upload-time = "2026-05-06T13:40:50.371Z" },
+    { url = "https://files.pythonhosted.org/packages/18/ae/fdb2f64316afca925640f8e70bb1a564b0ec2721c1389e25b8eb4bf9a299/pydantic_core-2.46.4-cp314-cp314-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:cd2213145bcc2ba85884d0ac63d222fece9209678f77b9b4d76f054c561adb28", size = 2307534, upload-time = "2026-05-06T13:37:21.531Z" },
+    { url = "https://files.pythonhosted.org/packages/89/1d/8eff589b45bb8190a9d12c49cfad0f176a5cbd1534908a6b5125e2886239/pydantic_core-2.46.4-cp314-cp314-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7a5f930472650a82629163023e630d160863fce524c616f4e5186e5de9d9a49b", size = 2099732, upload-time = "2026-05-06T13:39:31.942Z" },
+    { url = "https://files.pythonhosted.org/packages/06/d5/ee5a3366637fee41dee51a1fc91562dcf12ddbc68fda34e6b253da2324bb/pydantic_core-2.46.4-cp314-cp314-manylinux_2_31_riscv64.whl", hash = "sha256:c1b3f518abeca3aa13c712fd202306e145abf59a18b094a6bafb2d2bbf59192c", size = 2129627, upload-time = "2026-05-06T13:37:25.033Z" },
+    { url = "https://files.pythonhosted.org/packages/94/33/2414be571d2c6a6c4d08be21f9292b6d3fdb08949a97b6dfe985017821db/pydantic_core-2.46.4-cp314-cp314-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:1a7dd0b3ee80d90150e3495a3a13ac34dbcbfd4f012996a6a1d8900e91b5c0fb", size = 2179141, upload-time = "2026-05-06T13:37:14.046Z" },
+    { url = "https://files.pythonhosted.org/packages/7b/79/7daa95be995be0eecc4cf75064cb33f9bbbfe3fe0158caf2f0d4a996a5c7/pydantic_core-2.46.4-cp314-cp314-musllinux_1_1_aarch64.whl", hash = "sha256:3fb702cd90b0446a3a1c5e470bfa0dd23c0233b676a9099ddcc964fa6ca13898", size = 2184325, upload-time = "2026-05-06T13:36:53.615Z" },
+    { url = "https://files.pythonhosted.org/packages/9f/cb/d0a382f5c0de8a222dc61c65348e0ce831b1f68e0a018450d31c2cace3a5/pydantic_core-2.46.4-cp314-cp314-musllinux_1_1_armv7l.whl", hash = "sha256:b8458003118a712e66286df6a707db01c52c0f52f7db8e4a38f0da1d3b94fc4e", size = 2323990, upload-time = "2026-05-06T13:40:29.971Z" },
+    { url = "https://files.pythonhosted.org/packages/05/db/d9ba624cc4a5aced1598e88c04fdbd8310c8a69b9d38b9a3d39ce3a61ed7/pydantic_core-2.46.4-cp314-cp314-musllinux_1_1_x86_64.whl", hash = "sha256:372429a130e469c9cd698925ce5fc50940b7a1336b0d82038e63d5bbc4edc519", size = 2369978, upload-time = "2026-05-06T13:37:23.027Z" },
+    { url = "https://files.pythonhosted.org/packages/f2/20/d15df15ba918c423461905802bfd2981c3af0bfa0e40d05e13edbfa48bc3/pydantic_core-2.46.4-cp314-cp314-win32.whl", hash = "sha256:85bb3611ff1802f3ee7fdd7dbff26b56f343fb432d57a4728fdd49b6ef35e2f4", size = 1966354, upload-time = "2026-05-06T13:38:03.499Z" },
+    { url = "https://files.pythonhosted.org/packages/fc/b6/6b8de4c0a7d7ab3004c439c80c5c1e0a3e8d78bbae19379b01960383d9e5/pydantic_core-2.46.4-cp314-cp314-win_amd64.whl", hash = "sha256:811ff8e9c313ab425368bcbb36e5c4ebd7108c2bbf4e4089cfbb0b01eff63fac", size = 2072238, upload-time = "2026-05-06T13:39:40.807Z" },
+    { url = "https://files.pythonhosted.org/packages/32/36/51eb763beec1f4cf59b1db243a7dcc39cbb41230f050a09b9d69faaf0a48/pydantic_core-2.46.4-cp314-cp314-win_arm64.whl", hash = "sha256:bfec22eab3c8cc2ceec0248aec886624116dc079afa027ecc8ad4a7e62010f8a", size = 2018251, upload-time = "2026-05-06T13:37:26.72Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/91/855af51d625b23aa987116a19e231d2aaef9c4a415273ddc189b79a45fee/pydantic_core-2.46.4-cp314-cp314t-macosx_10_12_x86_64.whl", hash = "sha256:af8244b2bef6aaad6d92cda81372de7f8c8d36c9f0c3ea36e827c60e7d9467a0", size = 2099593, upload-time = "2026-05-06T13:39:47.682Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/1b/8784a54c65edb5f49f0a14d6977cf1b209bba85a4c77445b255c2de58ab3/pydantic_core-2.46.4-cp314-cp314t-macosx_11_0_arm64.whl", hash = "sha256:5a4330cdbc57162e4b3aa303f588ba752257694c9c9be3e7ebb11b4aca659b5d", size = 1935226, upload-time = "2026-05-06T13:40:40.428Z" },
+    { url = "https://files.pythonhosted.org/packages/e8/e7/1955d28d1afc56dd4b3ad7cc0cf39df1b9852964cf16e5d13912756d6d6b/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:29c61fc04a3d840155ff08e475a04809278972fe6aef51e2720554e96367e34b", size = 1974605, upload-time = "2026-05-06T13:37:32.029Z" },
+    { url = "https://files.pythonhosted.org/packages/93/e2/3fedbf0ba7a22850e6e9fd78117f1c0f10f950182344d8a6c535d468fdd8/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_17_armv7l.manylinux2014_armv7l.whl", hash = "sha256:c50f2528cf200c5eed56faf3f4e22fcd5f38c157a8b78576e6ba3168ec35f000", size = 2030777, upload-time = "2026-05-06T13:38:55.239Z" },
+    { url = "https://files.pythonhosted.org/packages/f8/61/46be275fcaaba0b4f5b9669dd852267ce1ff616592dccf7a7845588df091/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_17_ppc64le.manylinux2014_ppc64le.whl", hash = "sha256:0cbe8b01f948de4286c74cdd6c667aceb38f5c1e26f0693b3983d9d74887c65e", size = 2236641, upload-time = "2026-05-06T13:37:08.096Z" },
+    { url = "https://files.pythonhosted.org/packages/60/db/12e93e46a8bac9988be3c016860f83293daea8c716c029c9ace279036f2f/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_17_s390x.manylinux2014_s390x.whl", hash = "sha256:617d7e2ca7dcb8c5cf6bcb8c59b8832c94b36196bbf1cbd1bfb56ed341905edd", size = 2286404, upload-time = "2026-05-06T13:40:20.221Z" },
+    { url = "https://files.pythonhosted.org/packages/e2/4a/4d8b19008f38d31c53b8219cfedc2e3d5de5fe99d90076b7e767de29274f/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7027560ee92211647d0d34e3f7cd6f50da56399d26a9c8ad0da286d3869a53f3", size = 2109219, upload-time = "2026-05-06T13:38:12.153Z" },
+    { url = "https://files.pythonhosted.org/packages/88/70/3cbc40978fefb7bb09c6708d40d4ad1a5d70fd7213c3d17f971de868ec1f/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_31_riscv64.whl", hash = "sha256:f99626688942fb746e545232e7726926f3be91b5975f8b55327665fafda991c7", size = 2110594, upload-time = "2026-05-06T13:40:02.971Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/20/b8d36736216e29491125531685b2f9e61aa5b4b2599893f8268551da3338/pydantic_core-2.46.4-cp314-cp314t-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:fc3e9034a63de20e15e8ade85358bc6efc614008cab72898b4b4952bea0509ff", size = 2159542, upload-time = "2026-05-06T13:39:27.506Z" },
+    { url = "https://files.pythonhosted.org/packages/1d/a2/367df868eb584dacf6bf82a389272406d7178e301c4ac82545ab98bc2dd9/pydantic_core-2.46.4-cp314-cp314t-musllinux_1_1_aarch64.whl", hash = "sha256:97e7cf2be5c77b7d1a9713a05605d49460d02c6078d38d8bef3cbe323c548424", size = 2168146, upload-time = "2026-05-06T13:38:31.93Z" },
+    { url = "https://files.pythonhosted.org/packages/c1/b8/4460f77f7e201893f649a29ab355dddd3beee8a97bcb1a320db414f9a06e/pydantic_core-2.46.4-cp314-cp314t-musllinux_1_1_armv7l.whl", hash = "sha256:3bf92c5d0e00fefaab325a4d27828fe6b6e2a21848686b5b60d2d9eeb09d76c6", size = 2306309, upload-time = "2026-05-06T13:37:44.717Z" },
+    { url = "https://files.pythonhosted.org/packages/64/c4/be2639293acd87dc8ddbcec41a73cee9b2ebf996fe6d892a1a74e88ad3f7/pydantic_core-2.46.4-cp314-cp314t-musllinux_1_1_x86_64.whl", hash = "sha256:3ecbc122d18468d06ca279dc26a8c2e2d5acb10943bb35e36ae92096dc3b5565", size = 2369736, upload-time = "2026-05-06T13:37:05.645Z" },
+    { url = "https://files.pythonhosted.org/packages/30/a6/9f9f380dbb301f67023bf8f707aaa75daadf84f7152d95c410fd7e81d994/pydantic_core-2.46.4-cp314-cp314t-win32.whl", hash = "sha256:e846ae7835bf0703ae43f534ab79a867146dadd59dc9ca5c8b53d5c8f7c9ef02", size = 1955575, upload-time = "2026-05-06T13:38:51.116Z" },
+    { url = "https://files.pythonhosted.org/packages/40/1f/f1eb9eb350e795d1af8586289746f5c5677d16043040d63710e22abc43c9/pydantic_core-2.46.4-cp314-cp314t-win_amd64.whl", hash = "sha256:2108ba5c1c1eca18030634489dc544844144ee36357f2f9f780b93e7ddbb44b5", size = 2051624, upload-time = "2026-05-06T13:38:21.672Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/d2/42dd53d0a85c27606f316d3aa5d2869c4e8470a5ed6dec30e4a1abe19192/pydantic_core-2.46.4-cp314-cp314t-win_arm64.whl", hash = "sha256:4fcbe087dbc2068af7eda3aa87634eba216dbda64d1ae73c8684b621d33f6596", size = 2017325, upload-time = "2026-05-06T13:40:52.723Z" },
+    { url = "https://files.pythonhosted.org/packages/ee/a4/73995fd4ebbb46ba0ee51e6fa049b8f02c40daebb762208feda8a6b7894d/pydantic_core-2.46.4-graalpy311-graalpy242_311_native-macosx_10_12_x86_64.whl", hash = "sha256:14d4edf427bdcf950a8a02d7cb44a08614388dd6e1bdcbf4f67504fa7887da9c", size = 2111589, upload-time = "2026-05-06T13:37:10.817Z" },
+    { url = "https://files.pythonhosted.org/packages/fb/7f/f37d3a5e8bfcc2e403f5c57a730f2d815693fb42119e8ea48b3789335af1/pydantic_core-2.46.4-graalpy311-graalpy242_311_native-macosx_11_0_arm64.whl", hash = "sha256:0ce40cd7b21210e99342afafbd4d0f76d784eb5b1d60f3bdc566be4983c6c73b", size = 1944552, upload-time = "2026-05-06T13:36:56.717Z" },
+    { url = "https://files.pythonhosted.org/packages/15/3c/d7eb777b3ff43e8433a4efb39a17aa8fd98a4ee8561a24a67ef5db07b2d6/pydantic_core-2.46.4-graalpy311-graalpy242_311_native-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:90884113d8b48f760e9587002789ddd741e76ab9f89518cd1e43b1f1a52ec44b", size = 1982984, upload-time = "2026-05-06T13:39:06.207Z" },
+    { url = "https://files.pythonhosted.org/packages/63/87/70b9f40170a81afd55ca26c9b2acb25c20d64bcfbf888fafecb3ba077d4c/pydantic_core-2.46.4-graalpy311-graalpy242_311_native-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:66ce7632c22d837c95301830e111ad0128a32b8207533b60896a96c4915192ea", size = 2138417, upload-time = "2026-05-06T13:39:45.476Z" },
+    { url = "https://files.pythonhosted.org/packages/9d/1d/8987ad40f65ae1432753072f214fb5c74fe47ffbd0698bb9cbbb585664f8/pydantic_core-2.46.4-graalpy312-graalpy250_312_native-macosx_10_12_x86_64.whl", hash = "sha256:1d8ba486450b14f3b1d63bc521d410ec7565e52f887b9fb671791886436a42f7", size = 2095527, upload-time = "2026-05-06T13:39:52.283Z" },
+    { url = "https://files.pythonhosted.org/packages/64/d3/84c282a7eee1d3ac4c0377546ef5a1ea436ce26840d9ac3b7ed54a377507/pydantic_core-2.46.4-graalpy312-graalpy250_312_native-macosx_11_0_arm64.whl", hash = "sha256:3009f12e4e90b7f88b4f9adb1b0c4a3d58fe7820f3238c190047209d148026df", size = 1936024, upload-time = "2026-05-06T13:40:15.671Z" },
+    { url = "https://files.pythonhosted.org/packages/d7/ca/eac61596cdeb4d7e174d3dc0bd8a6238f14f75f97a24e7b7db4c7e7340a0/pydantic_core-2.46.4-graalpy312-graalpy250_312_native-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:ad785e92e6dc634c21555edc8bd6b64957ab844541bcb96a1366c202951ae526", size = 1990696, upload-time = "2026-05-06T13:38:34.717Z" },
+    { url = "https://files.pythonhosted.org/packages/fa/c3/7c8b240552251faf6b3a957db200fcfbbcec36763c050428b601e0c9b83b/pydantic_core-2.46.4-graalpy312-graalpy250_312_native-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:00c603d540afdd6b80eb39f078f33ebd46211f02f33e34a32d9f053bba711de0", size = 2147590, upload-time = "2026-05-06T13:39:29.883Z" },
+    { url = "https://files.pythonhosted.org/packages/11/cb/428de0385b6c8d44b716feba566abfacfbd23ee3c4439faa789a1456242f/pydantic_core-2.46.4-pp311-pypy311_pp73-macosx_10_12_x86_64.whl", hash = "sha256:0c563b08bca408dc7f65f700633d8442fffb2421fc47b8101377e9fd65051ff0", size = 2112782, upload-time = "2026-05-06T13:37:04.016Z" },
+    { url = "https://files.pythonhosted.org/packages/0b/b5/6a17bdadd0fc1f170adfd05a20d37c832f52b117b4d9131da1f41bb097ce/pydantic_core-2.46.4-pp311-pypy311_pp73-macosx_11_0_arm64.whl", hash = "sha256:db06ffe51636ffe9ca531fe9023dd64bdd794be8754cb5df57c5498ae5b518a7", size = 1952146, upload-time = "2026-05-06T13:39:43.092Z" },
+    { url = "https://files.pythonhosted.org/packages/2a/dc/03734d80e362cd43ef65428e9de77c730ce7f2f11c60d2b1e1b39f0fbf99/pydantic_core-2.46.4-pp311-pypy311_pp73-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:133878133d271ade3d41d1bfb2a45ec38dbdbda40bc065921c6b04e4630127e2", size = 2134492, upload-time = "2026-05-06T13:36:58.124Z" },
+    { url = "https://files.pythonhosted.org/packages/de/df/5e5ffc085ed07cc22d298134d3d911c63e91f6a0eb91fe646750a3209910/pydantic_core-2.46.4-pp311-pypy311_pp73-manylinux_2_5_i686.manylinux1_i686.whl", hash = "sha256:9bc519fbf2b7578398853d815009ae5e4d4603d12f4e3f91da8c06852d3da3e9", size = 2156604, upload-time = "2026-05-06T13:37:49.88Z" },
+    { url = "https://files.pythonhosted.org/packages/81/44/6e112a4253e56f5705467cbab7ab5e91ee7398ba3d56d358635958893d3e/pydantic_core-2.46.4-pp311-pypy311_pp73-musllinux_1_1_aarch64.whl", hash = "sha256:c7a7bd4e39e8e4c12c39cd480356842b6a8a06e41b23a55a5e3e191718838ddf", size = 2183828, upload-time = "2026-05-06T13:37:43.053Z" },
+    { url = "https://files.pythonhosted.org/packages/ac/ad/5565071e937d8e752842ac241463944c9eb14c87e2d269f2658a5bd05e98/pydantic_core-2.46.4-pp311-pypy311_pp73-musllinux_1_1_armv7l.whl", hash = "sha256:d396ec2b979760aaf3218e76c24e65bd0aca24983298653b3a9d7a45f9e47b30", size = 2310000, upload-time = "2026-05-06T13:37:56.694Z" },
+    { url = "https://files.pythonhosted.org/packages/4f/c3/66883a5cec183e7fba4d024b4cbbe61851a63750ef606b0afecc46d1f2bf/pydantic_core-2.46.4-pp311-pypy311_pp73-musllinux_1_1_x86_64.whl", hash = "sha256:86e1a4418c6cd97d60c95c71164158eaf7324fae7b0923264016baa993eba6fc", size = 2361286, upload-time = "2026-05-06T13:40:05.667Z" },
+    { url = "https://files.pythonhosted.org/packages/4b/2d/69abac8f838090bbecd5df894befb2c2619e7996a98ddb949db9f3b93225/pydantic_core-2.46.4-pp311-pypy311_pp73-win_amd64.whl", hash = "sha256:d51026d73fcfd93610abc7b27789c26b313920fcfb20e27462d74a7f8b06e983", size = 2193071, upload-time = "2026-05-06T13:38:08.682Z" },
+]
+
+[[package]]
+name = "pydantic-xml"
+version = "2.21.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "pydantic" },
+    { name = "pydantic-core" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/13/87/085533e0873b2f80bdeb12156ffe5dddae7ee55573e2057ad574d73e3b6a/pydantic_xml-2.21.0.tar.gz", hash = "sha256:678ba9149c24e190ad94d6e3ce47f94cbb1409fd88d7df65d3d26939ff669ed0", size = 26825, upload-time = "2026-05-17T15:24:19.534Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/8e/b1/278da37b539595b2cb6bb4fb3da1d69ff084c7bf5cc143f0a444550dc41a/pydantic_xml-2.21.0-py3-none-any.whl", hash = "sha256:966b8990746528304ebb96c97db7603ee3faf38f06266247b1fa444dbc16f8d6", size = 43449, upload-time = "2026-05-17T15:24:21.182Z" },
 ]
 
 [[package]]
@@ -581,6 +742,18 @@ source = { registry = "https://pypi.org/simple" }
 sdist = { url = "https://files.pythonhosted.org/packages/72/94/1a15dd82efb362ac84269196e94cf00f187f7ed21c242792a923cdb1c61f/typing_extensions-4.15.0.tar.gz", hash = "sha256:0cea48d173cc12fa28ecabc3b837ea3cf6f38c6d1136f85cbaaf598984861466", size = 109391, upload-time = "2025-08-25T13:49:26.313Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/18/67/36e9267722cc04a6b9f15c7f3441c2363321a3ea07da7ae0c0707beb2a9c/typing_extensions-4.15.0-py3-none-any.whl", hash = "sha256:f0fa19c6845758ab08074a0cfa8b7aecb71c999ca73d62883bc25cc018c4e548", size = 44614, upload-time = "2025-08-25T13:49:24.86Z" },
+]
+
+[[package]]
+name = "typing-inspection"
+version = "0.4.2"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "typing-extensions" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/55/e3/70399cb7dd41c10ac53367ae42139cf4b1ca5f36bb3dc6c9d33acdb43655/typing_inspection-0.4.2.tar.gz", hash = "sha256:ba561c48a67c5958007083d386c3295464928b01faa735ab8547c5692e87f464", size = 75949, upload-time = "2025-10-01T02:14:41.687Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/dc/9b/47798a6c91d8bdb567fe2698fe81e0c6b7cb7ef4d13da4114b41d239f65d/typing_inspection-0.4.2-py3-none-any.whl", hash = "sha256:4ed1cacbdc298c220f1bd249ed5287caa16f34d44ef4e9c3d0cbad5b521545e7", size = 14611, upload-time = "2025-10-01T02:14:40.154Z" },
 ]
 
 [[package]]

--- a/zensical.toml
+++ b/zensical.toml
@@ -1,7 +1,7 @@
 [project]
 site_name = "pybeerxml"
 site_url = "https://pybeerxml.onrender.com/"
-site_description = "A BeerXML parser for Python"
+site_description = "A BeerXML parser and serializer for Python"
 site_author = "Tom Herold"
 copyright = "Copyright 2026 Tom Herold"
 docs_dir = "docs"
@@ -30,6 +30,7 @@ Home = "index.md"
 "API Reference" = [
   { Overview = "api/index.md" },
   { Parser = "api/parser.md" },
+  { Serializer = "api/serializer.md" },
   { Recipe = "api/recipe.md" },
   { Fermentable = "api/fermentable.md" },
   { Hop = "api/hop.md" },


### PR DESCRIPTION
## Summary

Refactors BeerXML parsing and serialization around [pydantic](https://docs.pydantic.dev/) and [pydantic-xml](https://pydantic-xml.readthedocs.io/):

- **Models migrated to pydantic-xml** — all 10 BeerXML models now subclass a shared `BeerXmlModel` base with explicit element mappings, wrapped lists (`HOPS/HOP`, `MASH_STEPS/MASH_STEP`, …), `unordered` search mode (real-world files don't follow field order), assignment validation, and `TRUE`/`FALSE` boolean serialization per the spec. Lenient union types keep non-numeric XML content as strings (`<GRAIN_TEMP>unknown</GRAIN_TEMP>`, `<EST_COLOR>79 EBC</EST_COLOR>`, alphanumeric yeast product IDs) instead of failing validation.
- **New class-based `Serializer`** alongside `Parser`, both exposed from the package root: `serialize(recipes, path)` / `serialize_to_string(recipes)`. Pretty-printed output, `None` fields omitted, calculated properties never written.
- **Behavior preserved** — stored metrics live in `og_`/`fg_`/`ibu_`/`abv_`/`color_` (and `yield_` on `Fermentable`); the previous private names (`_og`, `_yield`, …) remain as compatibility aliases; `og`/`fg`/… keep their stored-or-calculated fallback; all recipe calculation formulas untouched.
- **Tests** — new `tests/test_serializer.py` (structure, uppercase booleans, `YIELD` element, unset-field omission, file output, full fixture round-trips incl. calculated-value stability and compat aliases); existing suite unchanged except rewriting the removed internal `node_to_object` test.
- **Docs** — README and getting-started gain serialization usage; API reference adds a `Serializer` page, stored-vs-calculated field table, and updated import paths.
- **Dependencies** — adds `pydantic>=2.0` and `pydantic-xml>=2.0`; version bumped to **3.0.0** (breaking: old internal `Parser` methods removed).

## Verification

- `uv run pytest` — 112 passed
- `uv run ruff format . && uv run ruff check .` — clean
- `uv run ty check pybeerxml` — clean
- `uv run zensical build` — docs build successfully